### PR TITLE
feat: 로그인 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,6 +53,7 @@ dependencies {
     //jwt
     implementation 'io.jsonwebtoken:jjwt:0.9.1'
 
+    //DatatypeConverter
     implementation 'javax.xml.bind:jaxb-api:2.3.1'
     implementation 'org.glassfish.jaxb:jaxb-runtime:2.3.1'
 

--- a/build.gradle
+++ b/build.gradle
@@ -49,6 +49,13 @@ dependencies {
 
     testImplementation 'org.junit.jupiter:junit-jupiter:5.10.0'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+
+    //jwt
+    implementation 'io.jsonwebtoken:jjwt:0.9.1'
+
+    implementation 'javax.xml.bind:jaxb-api:2.3.1'
+    implementation 'org.glassfish.jaxb:jaxb-runtime:2.3.1'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/codeit/todo/common/config/JwtTokenProvider.java
+++ b/src/main/java/com/codeit/todo/common/config/JwtTokenProvider.java
@@ -1,0 +1,79 @@
+package com.codeit.todo.common.config;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import jakarta.annotation.PostConstruct;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.stereotype.Component;
+
+import java.util.Base64;
+import java.util.Date;
+
+@Component
+@RequiredArgsConstructor
+public class JwtTokenProvider {
+
+    @Value("${jwtpassword.source}")
+    private String secretKeySource;
+    private String secretKey;
+
+    @PostConstruct
+    public void setUp(){
+        secretKey = Base64.getEncoder()
+                .encodeToString(secretKeySource.getBytes());
+    }
+
+    private long tokenValidMilliSeconds =1000L*60*60; //1시간
+
+    private final UserDetailsService userDetailsService;
+
+    public String createToken(String email){
+        Claims claims = Jwts.claims().setSubject(email);
+        Date now = new Date();
+        return Jwts.builder()
+                .setClaims(claims)
+                .setIssuedAt(now)
+                .setExpiration(new Date(now.getTime()+tokenValidMilliSeconds))
+                .signWith(SignatureAlgorithm.HS256, secretKey)
+                .compact();
+    }
+
+    public String resolveToken(HttpServletRequest request){
+        return request.getHeader("token");
+    }
+
+    public boolean validToken(String jwtToken){
+        try{
+            Claims claims = Jwts.parser()
+                    .setSigningKey(secretKey)
+                    .parseClaimsJws(jwtToken)
+                    .getBody();
+            Date now = new Date();
+            return claims.getExpiration().after(now);
+        }catch(Exception e){
+            return false;
+        }
+    }
+
+    public Authentication getAuthentication(String jwtToken){
+        UserDetails userDetails = userDetailsService.loadUserByUsername(getUserEmail(jwtToken));
+        return new UsernamePasswordAuthenticationToken(userDetails, " ", userDetails.getAuthorities());
+    }
+
+    public String getUserEmail(String jwtToken) {
+        return Jwts.parser()
+                .setSigningKey(secretKey)
+                .parseClaimsJws(jwtToken)
+                .getBody()
+                .getSubject();
+    }
+
+
+}

--- a/src/main/java/com/codeit/todo/common/config/SecurityConfig.java
+++ b/src/main/java/com/codeit/todo/common/config/SecurityConfig.java
@@ -1,13 +1,23 @@
 package com.codeit.todo.common.config;
 
+import com.codeit.todo.common.exception.CustomAccessDeniedHandler;
+import com.codeit.todo.common.exception.CustomAuthenticationEntryPoint;
+import com.codeit.todo.web.filter.JwtAuthenticationFilter;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
+@RequiredArgsConstructor
 public class SecurityConfig {
+
+    private final JwtTokenProvider jwtTokenProvider;
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
@@ -20,8 +30,18 @@ public class SecurityConfig {
                     .requestMatchers("/swagger/**").permitAll()
                     .requestMatchers("/**").permitAll()
                     .anyRequest().permitAll()
-//                    .anyRequest().authenticated() // 인증 구현시, 주석 해제
-            );
+//                    .anyRequest().authenticated()
+            )
+                .exceptionHandling( e->{
+                e.authenticationEntryPoint(new CustomAuthenticationEntryPoint());
+                e.accessDeniedHandler(new CustomAccessDeniedHandler());
+                })
+                .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider), UsernamePasswordAuthenticationFilter.class);
         return http.build();
+    }
+
+    @Bean
+    public AuthenticationManager authenticationManager(AuthenticationConfiguration authenticationConfiguration) throws Exception {
+        return authenticationConfiguration.getAuthenticationManager();
     }
 }

--- a/src/main/java/com/codeit/todo/common/config/SecurityConfig.java
+++ b/src/main/java/com/codeit/todo/common/config/SecurityConfig.java
@@ -30,12 +30,8 @@ public class SecurityConfig {
                     .requestMatchers("/swagger/**").permitAll()
                     .requestMatchers("/**").permitAll()
                     .anyRequest().permitAll()
-//                    .anyRequest().authenticated()
+//                        .anyRequest().authenticated()
             )
-                .exceptionHandling( e->{
-                e.authenticationEntryPoint(new CustomAuthenticationEntryPoint());
-                e.accessDeniedHandler(new CustomAccessDeniedHandler());
-                })
                 .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider), UsernamePasswordAuthenticationFilter.class);
         return http.build();
     }

--- a/src/main/java/com/codeit/todo/common/exception/CustomAccessDeniedHandler.java
+++ b/src/main/java/com/codeit/todo/common/exception/CustomAccessDeniedHandler.java
@@ -1,0 +1,19 @@
+package com.codeit.todo.common.exception;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+public class CustomAccessDeniedHandler implements AccessDeniedHandler {
+
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response, AccessDeniedException accessDeniedException) throws IOException, ServletException {
+        response.sendRedirect("/api/vi/exceptions/access-denied");
+    }
+}

--- a/src/main/java/com/codeit/todo/common/exception/CustomAccessDeniedHandler.java
+++ b/src/main/java/com/codeit/todo/common/exception/CustomAccessDeniedHandler.java
@@ -1,19 +1,31 @@
 package com.codeit.todo.common.exception;
 
+import com.codeit.todo.common.exception.payload.ErrorStatus;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import lombok.Getter;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.web.access.AccessDeniedHandler;
 import org.springframework.stereotype.Component;
 
 import java.io.IOException;
+import java.time.LocalDateTime;
 
-@Component
-public class CustomAccessDeniedHandler implements AccessDeniedHandler {
 
-    @Override
-    public void handle(HttpServletRequest request, HttpServletResponse response, AccessDeniedException accessDeniedException) throws IOException, ServletException {
-        response.sendRedirect("/api/vi/exceptions/access-denied");
+@Getter
+public class CustomAccessDeniedHandler extends ApplicationException {
+
+    private static final String ENTITY_NOT_FOUND_EXCEPTION_MESSAGE = "접근이 제한되었습니다.";
+    private static final int ENTITY_NOT_FOUND_EXCEPTION_STATUS_CODE = 403;
+
+    private final String entityId;
+    private final String entityType;
+
+    public CustomAccessDeniedHandler(String entityId, String entityType) {
+        super(new ErrorStatus(ENTITY_NOT_FOUND_EXCEPTION_MESSAGE, ENTITY_NOT_FOUND_EXCEPTION_STATUS_CODE, LocalDateTime.now()));
+        this.entityId = entityId;
+        this.entityType = entityType;
     }
+
 }

--- a/src/main/java/com/codeit/todo/common/exception/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/codeit/todo/common/exception/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,18 @@
+package com.codeit.todo.common.exception;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException, ServletException {
+        response.sendRedirect("/api/v1/exceptions/entrypoint");
+    }
+}

--- a/src/main/java/com/codeit/todo/common/exception/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/codeit/todo/common/exception/CustomAuthenticationEntryPoint.java
@@ -1,18 +1,31 @@
 package com.codeit.todo.common.exception;
 
+import com.codeit.todo.common.exception.payload.ErrorStatus;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import lombok.Getter;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.stereotype.Component;
 
 import java.io.IOException;
+import java.time.LocalDateTime;
 
-@Component
-public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
-    @Override
-    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException, ServletException {
-        response.sendRedirect("/api/v1/exceptions/entrypoint");
+
+@Getter
+public class CustomAuthenticationEntryPoint extends ApplicationException {
+
+    private static final String ENTITY_NOT_FOUND_EXCEPTION_MESSAGE = "권한이 없습니다.";
+    private static final int ENTITY_NOT_FOUND_EXCEPTION_STATUS_CODE = 401;
+
+    private final String entityId;
+    private final String entityType;
+
+    public CustomAuthenticationEntryPoint(String entityId, String entityType) {
+        super(new ErrorStatus(ENTITY_NOT_FOUND_EXCEPTION_MESSAGE, ENTITY_NOT_FOUND_EXCEPTION_STATUS_CODE, LocalDateTime.now()));
+        this.entityId = entityId;
+        this.entityType = entityType;
     }
+
 }

--- a/src/main/java/com/codeit/todo/common/handler/GlobalRestControllerAdvice.java
+++ b/src/main/java/com/codeit/todo/common/handler/GlobalRestControllerAdvice.java
@@ -28,13 +28,4 @@ public class GlobalRestControllerAdvice {
         return new ResponseEntity<>(errorStatus, errorStatus.toHttpStatus());
     }
 
-    @GetMapping(value= "/entrypoint")
-    public void entryPointException(){
-        throw new NullPointerException("로그인이 필요합니다");
-    }
-
-    @GetMapping(value="/access-denied")
-    public void accessDeniedException(){
-        throw new NullPointerException("권한이 없습니다.");
-    }
 }

--- a/src/main/java/com/codeit/todo/common/handler/GlobalRestControllerAdvice.java
+++ b/src/main/java/com/codeit/todo/common/handler/GlobalRestControllerAdvice.java
@@ -5,10 +5,13 @@ import com.codeit.todo.common.exception.payload.ErrorStatus;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 @RestControllerAdvice
 @RequiredArgsConstructor
+@RequestMapping(value="/api/v1/exceptions")
 public class GlobalRestControllerAdvice {
 
     /**
@@ -23,5 +26,15 @@ public class GlobalRestControllerAdvice {
         ErrorStatus errorStatus = e.getErrorStatus();
 
         return new ResponseEntity<>(errorStatus, errorStatus.toHttpStatus());
+    }
+
+    @GetMapping(value= "/entrypoint")
+    public void entryPointException(){
+        throw new NullPointerException("로그인이 필요합니다");
+    }
+
+    @GetMapping(value="/access-denied")
+    public void accessDeniedException(){
+        throw new NullPointerException("권한이 없습니다.");
     }
 }

--- a/src/main/java/com/codeit/todo/common/handler/GlobalRestControllerAdvice.java
+++ b/src/main/java/com/codeit/todo/common/handler/GlobalRestControllerAdvice.java
@@ -11,7 +11,6 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 @RestControllerAdvice
 @RequiredArgsConstructor
-@RequestMapping(value="/api/v1/exceptions")
 public class GlobalRestControllerAdvice {
 
     /**

--- a/src/main/java/com/codeit/todo/repository/CustomUserDetails.java
+++ b/src/main/java/com/codeit/todo/repository/CustomUserDetails.java
@@ -1,0 +1,57 @@
+package com.codeit.todo.repository;
+
+import lombok.*;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+import java.util.List;
+
+@Builder
+@Getter
+@Setter
+@AllArgsConstructor
+@ToString
+@NoArgsConstructor
+public class CustomUserDetails implements UserDetails {
+
+    private Integer userId;
+    private String email;
+    private String password;
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return List.of(new SimpleGrantedAuthority("USER"));
+    }
+
+    @Override
+    public String getPassword() {
+        return this.password;
+    }
+
+    @Override
+    public String getUsername() {
+        return this.email;
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+}

--- a/src/main/java/com/codeit/todo/repository/UserRepository.java
+++ b/src/main/java/com/codeit/todo/repository/UserRepository.java
@@ -4,9 +4,11 @@ package com.codeit.todo.repository;
 import com.codeit.todo.domain.Todo;
 import com.codeit.todo.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
 
+@Repository
 public interface UserRepository extends JpaRepository<User, Integer> {
 
 

--- a/src/main/java/com/codeit/todo/repository/UserRepository.java
+++ b/src/main/java/com/codeit/todo/repository/UserRepository.java
@@ -1,6 +1,14 @@
 package com.codeit.todo.repository;
 
 
-public interface UserRepository {
+import com.codeit.todo.domain.Todo;
+import com.codeit.todo.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
+public interface UserRepository extends JpaRepository<User, Integer> {
+
+
+    Optional<User> findByEmail(String email);
 }

--- a/src/main/java/com/codeit/todo/service/CustomUserDetailService.java
+++ b/src/main/java/com/codeit/todo/service/CustomUserDetailService.java
@@ -1,0 +1,29 @@
+package com.codeit.todo.service;
+
+import com.codeit.todo.common.exception.user.UserNotFoundException;
+import com.codeit.todo.domain.User;
+import com.codeit.todo.repository.CustomUserDetails;
+import com.codeit.todo.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CustomUserDetailService implements UserDetailsService {
+
+    private final UserRepository userRepository;
+    @Override
+    public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(()-> new UserNotFoundException(email, "User"));
+
+        return CustomUserDetails.builder()
+                .userId(user.getUserId())
+                .email(user.getEmail())
+                .password(user.getPassword())
+                .build();
+    }
+}

--- a/src/main/java/com/codeit/todo/service/user/UserService.java
+++ b/src/main/java/com/codeit/todo/service/user/UserService.java
@@ -1,5 +1,8 @@
 package com.codeit.todo.service.user;
 
+import com.codeit.todo.web.dto.request.auth.LoginRequest;
+
 public interface UserService {
 
+    String login(LoginRequest loginRequest);
 }

--- a/src/main/java/com/codeit/todo/service/user/impl/UserServiceImpl.java
+++ b/src/main/java/com/codeit/todo/service/user/impl/UserServiceImpl.java
@@ -1,9 +1,52 @@
 package com.codeit.todo.service.user.impl;
 
+import com.codeit.todo.common.config.JwtTokenProvider;
+import com.codeit.todo.common.exception.ApplicationException;
+import com.codeit.todo.common.exception.payload.ErrorStatus;
+import com.codeit.todo.common.exception.user.UserNotFoundException;
+import com.codeit.todo.domain.User;
+import com.codeit.todo.repository.UserRepository;
 import com.codeit.todo.service.user.UserService;
+import com.codeit.todo.web.dto.request.auth.LoginRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDateTime;
+
 @Service
+@RequiredArgsConstructor
 public class UserServiceImpl implements UserService {
+    private final UserRepository userRepository;
+    private final AuthenticationManager authenticationManager;
+    private final JwtTokenProvider jwtTokenProvider;
+
+
+
+    public String login(LoginRequest loginRequest){
+        String email = loginRequest.email();
+        String password = loginRequest.password();
+
+        try{
+            Authentication authentication = authenticationManager.authenticate(new UsernamePasswordAuthenticationToken(email, password));
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+
+            User user = userRepository.findByEmail(email)
+                    .orElseThrow(()-> new UserNotFoundException(email, "User"));
+
+            return jwtTokenProvider.createToken(email);
+        }catch(Exception e){
+            e.printStackTrace();
+            throw new ApplicationException(new ErrorStatus(
+                    "로그인 과정에서 에러 발생",
+                    500,
+                    LocalDateTime.now()
+            ));
+        }
+    }
 
 }

--- a/src/main/java/com/codeit/todo/service/user/impl/UserServiceImpl.java
+++ b/src/main/java/com/codeit/todo/service/user/impl/UserServiceImpl.java
@@ -32,11 +32,11 @@ public class UserServiceImpl implements UserService {
         String password = loginRequest.password();
 
         try{
-            Authentication authentication = authenticationManager.authenticate(new UsernamePasswordAuthenticationToken(email, password));
-            SecurityContextHolder.getContext().setAuthentication(authentication);
-
             User user = userRepository.findByEmail(email)
                     .orElseThrow(()-> new UserNotFoundException(email, "User"));
+
+            Authentication authentication = authenticationManager.authenticate(new UsernamePasswordAuthenticationToken(email, password));
+            SecurityContextHolder.getContext().setAuthentication(authentication);
 
             return jwtTokenProvider.createToken(email);
         }catch(Exception e){

--- a/src/main/java/com/codeit/todo/web/controller/AuthController.java
+++ b/src/main/java/com/codeit/todo/web/controller/AuthController.java
@@ -1,8 +1,35 @@
 package com.codeit.todo.web.controller;
 
+import com.codeit.todo.service.user.UserService;
+import com.codeit.todo.web.dto.request.auth.LoginRequest;
+import com.codeit.todo.web.dto.response.Response;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/auth")
 public class AuthController {
+
+    private final UserService userService;
+
+    @Operation(summary = "로그인", description = "이메일과 비밀번호를 받아 로그인 진행")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "로그인 성공")
+    })
+    @PostMapping(value = "/login")
+    public Response login(@RequestBody LoginRequest loginRequest, HttpServletResponse httpServletResponse){
+        String email = loginRequest.email();
+        String token= userService.login(loginRequest);
+        httpServletResponse.setHeader("token", token);
+        return Response.ok( "로그인 성공");
+    }
 
 }

--- a/src/main/java/com/codeit/todo/web/controller/AuthController.java
+++ b/src/main/java/com/codeit/todo/web/controller/AuthController.java
@@ -15,7 +15,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/v1/auth")
+@RequestMapping("/api/v1/auths")
 public class AuthController {
 
     private final UserService userService;
@@ -26,7 +26,6 @@ public class AuthController {
     })
     @PostMapping(value = "/login")
     public Response login(@RequestBody LoginRequest loginRequest, HttpServletResponse httpServletResponse){
-        String email = loginRequest.email();
         String token= userService.login(loginRequest);
         httpServletResponse.setHeader("token", token);
         return Response.ok( "로그인 성공");

--- a/src/main/java/com/codeit/todo/web/dto/request/auth/LoginRequest.java
+++ b/src/main/java/com/codeit/todo/web/dto/request/auth/LoginRequest.java
@@ -1,5 +1,7 @@
 package com.codeit.todo.web.dto.request.auth;
 
+
+
 public record LoginRequest(String email, String password) {
 
 }

--- a/src/main/java/com/codeit/todo/web/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/codeit/todo/web/filter/JwtAuthenticationFilter.java
@@ -1,0 +1,31 @@
+package com.codeit.todo.web.filter;
+
+import com.codeit.todo.common.config.JwtTokenProvider;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        String jwtToken =jwtTokenProvider.resolveToken(request);
+
+
+        if(jwtToken != null && jwtTokenProvider.validToken(jwtToken)){
+            Authentication auth = jwtTokenProvider.getAuthentication(jwtToken);
+            SecurityContextHolder.getContext().setAuthentication(auth);
+        }
+        filterChain.doFilter(request, response);
+    }
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -25,13 +25,13 @@ spring:
       ddl-auto: update
     defer-datasource-initialization: true
 
-
-jwtpassword:
-  source: ${JWT_SECRET_KEY}
   servlet:
     multipart:
       max-file-size: 50MB
       max-request-size: 50MB
+
+jwtpassword:
+  source: ${JWT_SECRET_KEY}
 
   cloud:
     aws:

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -24,3 +24,6 @@ spring:
     hibernate:
       ddl-auto: update
     defer-datasource-initialization: true
+
+jwtpassword:
+  source: ${JWT_SECRET_KEY}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -19,7 +19,10 @@ spring:
         static: ap-northeast-2
       s3:
         bucket: fake-bucket-name
-    
+
+jwtpassword:
+  source: fake-secret-key
+
 logging:
   level:
     org.hibernate.SQL: debug


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

- 목표부터는 이슈 만들겠습니다..! 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- JWT로 로그인 구현했습니다. 
- 이메일을 비교하고 로그인 가능 여부를 판단합니다. 
- build.gradle에 jwt, DatatypeConverter 의존성 추가하였습니다. 
- 아직 회원가입 구현 전이라, 비밀번호를 해싱하는 기능이 없어서 로그인 할 때 에러가 나더라구요. 
임시로 비밀번호 앞에 {noop}을 추가해두어서 해결했고, 회원가입 구현 후에 삭제하겠습니다. (DB보시면 비밀번호 제가 바꿔두었습니다.)

### 스크린샷 (선택)
<img width="517" alt="Screenshot 2024-12-09 at 13 05 12" src="https://github.com/user-attachments/assets/c60323d1-1eaa-4bb2-af37-c8b2c1d540f2">


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> securityConfig 에 주석으로 //.anyRequest().authenticated() 처리된 부분 살릴까요?
> 유저에게 역할(role)이 없어서 그냥 default값으로 "USER"이 들어가도록 했습니다만, 없앨까요?
> 로그인 실패 또는 권한이 없을 때 exception을 설정해 두었는데, 수정할 필요 있는지 확인 부탁드립니다. 