### PR TITLE
fix: todoStatus type을 String으로 변경, GoalNotFoundException으로 변경

### DIFF
--- a/src/main/java/com/codeit/todo/domain/Todo.java
+++ b/src/main/java/com/codeit/todo/domain/Todo.java
@@ -30,7 +30,7 @@ public class Todo {
     private LocalDate endDate;
 
     @Column(length = 50, nullable = false)
-    private Boolean todoStatus;
+    private String todoStatus;
 
     @Column(nullable = false)
     private LocalDateTime createdAt;
@@ -46,7 +46,7 @@ public class Todo {
     private List<Complete> completes = new ArrayList<>();
 
     @Builder
-    public Todo(int todoId, String todoTitle, LocalDate startDate, LocalDate endDate, Boolean todoStatus, LocalDateTime createdAt, String todoLink, String todoPic, Goal goal) {
+    public Todo(int todoId, String todoTitle, LocalDate startDate, LocalDate endDate, String todoStatus, LocalDateTime createdAt, String todoLink, String todoPic, Goal goal) {
         this.todoId = todoId;
         this.todoTitle = todoTitle;
         this.startDate = startDate;

--- a/src/main/java/com/codeit/todo/service/todo/impl/TodoServiceImpl.java
+++ b/src/main/java/com/codeit/todo/service/todo/impl/TodoServiceImpl.java
@@ -1,6 +1,6 @@
 package com.codeit.todo.service.todo.impl;
 
-import com.codeit.todo.common.exception.EntityNotFoundException;
+import com.codeit.todo.common.exception.goal.GoalNotFoundException;
 import com.codeit.todo.domain.Complete;
 import com.codeit.todo.domain.Goal;
 import com.codeit.todo.domain.Todo;
@@ -104,7 +104,7 @@ public class TodoServiceImpl implements TodoService {
         }
 
         Goal goal = goalRepository.findByGoalIdAndUser_UserId(request.goalId(), userId)
-                .orElseThrow(() -> new EntityNotFoundException(String.valueOf(request.goalId()), "goal"));
+                .orElseThrow(() -> new GoalNotFoundException(String.valueOf(request.goalId())));
         Todo todo = request.toEntity(uploadUrl, goal);
         Todo savedTodo = todoRepository.save(todo);
 

--- a/src/main/java/com/codeit/todo/web/dto/request/todo/CreateTodoRequest.java
+++ b/src/main/java/com/codeit/todo/web/dto/request/todo/CreateTodoRequest.java
@@ -27,7 +27,7 @@ public record CreateTodoRequest(
                         .endDate(this.endDate)
                         .todoLink(this.todoLink)
                         .todoPic(uploadUrl)
-                        .todoStatus(false)
+                        .todoStatus("진행")
                         .createdAt(LocalDateTime.now())
                         .goal(goal)
                         .build();

--- a/src/main/java/com/codeit/todo/web/dto/response/todo/ReadTodoWithGoalResponse.java
+++ b/src/main/java/com/codeit/todo/web/dto/response/todo/ReadTodoWithGoalResponse.java
@@ -8,7 +8,7 @@ public record ReadTodoWithGoalResponse(
         String todoTitle,
         LocalDate startDate,
         LocalDate endDate,
-        Boolean todoStatus,
+        String todoStatus,
         String todoLink,
         String todoPic,
         LocalDateTime createdAt,

--- a/src/main/java/com/codeit/todo/web/dto/response/todo/ReadTodosResponse.java
+++ b/src/main/java/com/codeit/todo/web/dto/response/todo/ReadTodosResponse.java
@@ -13,7 +13,7 @@ public record ReadTodosResponse(
         String todoTitle,
         LocalDate startDate,
         LocalDate endDate,
-        Boolean todoStatus,
+        String todoStatus,
         String todoLink,
         String todoPic,
         LocalDateTime createdAt,


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

- close #55 

## 📝작업 내용

> todoStatus type을 String으로 변경하였습니다. 
> EntityNotFoundException을 GoalNotFoundException으로 변경하였습니다. 

### 스크린샷 (선택)
- 새로운 todo가 생성되면 todoStatus는 "진행"으로 들어갑니다. 
<img width="781" alt="Screenshot 2024-12-11 at 13 59 10" src="https://github.com/user-attachments/assets/b5ea4c1b-8fd7-46c7-95db-42a48a191f21">


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메소드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?