### PR TITLE
fix: 로그인 시 토큰을 쿠키로 내려주기

### DIFF
--- a/src/main/java/com/codeit/todo/common/config/JwtTokenProvider.java
+++ b/src/main/java/com/codeit/todo/common/config/JwtTokenProvider.java
@@ -4,6 +4,7 @@ import com.codeit.todo.common.exception.jwt.JwtException;
 import com.codeit.todo.common.exception.payload.ErrorStatus;
 import io.jsonwebtoken.*;
 import jakarta.annotation.PostConstruct;
+import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
@@ -22,6 +23,10 @@ public class JwtTokenProvider {
 
     private static final int UNAUTHORIZED = 401;
     private static final long TOKEN_VALID_MILLI_SECONDS =1000L*60*60; //1시간
+
+    private static final int COOKIE_VALID_SECONDS = 60*60*24; //24시간?
+
+
 
     @Value("${jwtpassword.source}")
     private String secretKeySource;
@@ -45,6 +50,20 @@ public class JwtTokenProvider {
                 .signWith(SignatureAlgorithm.HS256, secretKey)
                 .compact();
     }
+
+    public Cookie createCookie(String email){
+        String cookieName = "token";
+        String cookieValue= createToken(email);
+
+        Cookie cookie = new Cookie(cookieName, cookieValue);
+        cookie.setHttpOnly(true);
+        cookie.setSecure(true);
+        cookie.setPath("/");
+        cookie.setMaxAge(COOKIE_VALID_SECONDS);
+
+        return cookie;
+    }
+
 
     public String resolveToken(HttpServletRequest request){
         return request.getHeader("token");

--- a/src/main/java/com/codeit/todo/common/config/JwtTokenProvider.java
+++ b/src/main/java/com/codeit/todo/common/config/JwtTokenProvider.java
@@ -25,7 +25,7 @@ public class JwtTokenProvider {
     private static final int UNAUTHORIZED = 401;
     private static final long TOKEN_VALID_MILLI_SECONDS =1000L*60*60; //1시간
 
-    private static final int COOKIE_VALID_SECONDS = 60*60*24; //24시간?
+    private static final int COOKIE_VALID_SECONDS = 60*60*24; //24시간
 
 
 

--- a/src/main/java/com/codeit/todo/common/config/JwtTokenProvider.java
+++ b/src/main/java/com/codeit/todo/common/config/JwtTokenProvider.java
@@ -10,6 +10,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.parameters.P;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.stereotype.Component;
@@ -66,7 +67,16 @@ public class JwtTokenProvider {
 
 
     public String resolveToken(HttpServletRequest request){
-        return request.getHeader("token");
+        String token = null;
+
+        if(request.getCookies() != null){
+            for(Cookie cookie : request.getCookies()){
+                if(cookie.getName().equals("token")) {
+                    token = cookie.getValue();
+                }
+            }
+        }
+        return token;
     }
 
     public boolean validToken(String jwtToken){

--- a/src/main/java/com/codeit/todo/web/controller/AuthController.java
+++ b/src/main/java/com/codeit/todo/web/controller/AuthController.java
@@ -1,11 +1,13 @@
 package com.codeit.todo.web.controller;
 
+import com.codeit.todo.common.config.JwtTokenProvider;
 import com.codeit.todo.service.user.UserService;
 import com.codeit.todo.web.dto.request.auth.LoginRequest;
 import com.codeit.todo.web.dto.response.Response;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -19,6 +21,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class AuthController {
 
     private final UserService userService;
+    private final JwtTokenProvider jwtTokenProvider;
 
     @Operation(summary = "로그인", description = "이메일과 비밀번호를 받아 로그인 진행")
     @ApiResponses(value = {
@@ -27,7 +30,10 @@ public class AuthController {
     @PostMapping(value = "/login")
     public Response login(@RequestBody LoginRequest loginRequest, HttpServletResponse httpServletResponse){
         String token= userService.login(loginRequest);
+        Cookie cookie = jwtTokenProvider.createCookie(loginRequest.email());
+
         httpServletResponse.setHeader("token", token);
+        httpServletResponse.addCookie(cookie);
         return Response.ok( "로그인 성공");
     }
 

--- a/src/main/java/com/codeit/todo/web/controller/AuthController.java
+++ b/src/main/java/com/codeit/todo/web/controller/AuthController.java
@@ -33,13 +33,6 @@ public class AuthController {
         Cookie cookie = jwtTokenProvider.createCookie(loginRequest.email());
         httpServletResponse.addCookie(cookie);
         return Response.ok( "로그인 성공");
-
-//        if(token != null){
-//
-//        }else{
-//            return Response.ok("로그인 실패");
-//        }
-
     }
 
 }

--- a/src/main/java/com/codeit/todo/web/controller/AuthController.java
+++ b/src/main/java/com/codeit/todo/web/controller/AuthController.java
@@ -29,12 +29,17 @@ public class AuthController {
     })
     @PostMapping(value = "/login")
     public Response login(@RequestBody LoginRequest loginRequest, HttpServletResponse httpServletResponse){
-        String token= userService.login(loginRequest);
+        userService.login(loginRequest);
         Cookie cookie = jwtTokenProvider.createCookie(loginRequest.email());
-
-        httpServletResponse.setHeader("token", token);
         httpServletResponse.addCookie(cookie);
         return Response.ok( "로그인 성공");
+
+//        if(token != null){
+//
+//        }else{
+//            return Response.ok("로그인 실패");
+//        }
+
     }
 
 }

--- a/src/main/java/com/codeit/todo/web/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/codeit/todo/web/filter/JwtAuthenticationFilter.java
@@ -7,7 +7,6 @@ import com.codeit.todo.common.exception.payload.ErrorStatus;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
-import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
@@ -34,7 +33,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         try {
             if (jwtToken == null) {
                 throw new JwtException(ErrorStatus.toErrorStatus(
-                        "요청 헤더에 JWT 토큰이 비어있습니다.", 401
+                        "쿠키의 JWT 토큰이 비어있습니다.", 401
                 ));
             }
 

--- a/src/main/java/com/codeit/todo/web/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/codeit/todo/web/filter/JwtAuthenticationFilter.java
@@ -7,6 +7,7 @@ import com.codeit.todo.common.exception.payload.ErrorStatus;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

- close #56 

## 📝작업 내용

- 로그인 시 JWT를 헤더에 저장하는게 아니라, 쿠키에 넣어 보냅니다. 
- 요청을 받을 때도 쿠키로 받습니다. 

### 스크린샷 (선택)

<img width="890" alt="Screenshot 2024-12-12 at 16 05 25" src="https://github.com/user-attachments/assets/6f80f8c0-f52b-4f71-beae-7486ae781034" />


## 💬리뷰 요구사항(선택)

- 프론트의 기범님과 이야기해서 쿠키는 24시간으로 설정하였습니다만, 현재 토큰 유효시간은 1시간입니다. 
- 이는 추후 refresh token을 추가하며 보완해야 할 것 같습니다. 