### PR TITLE
feat: 회원가입

### DIFF
--- a/src/main/java/com/codeit/todo/common/config/JwtTokenProvider.java
+++ b/src/main/java/com/codeit/todo/common/config/JwtTokenProvider.java
@@ -24,7 +24,6 @@ public class JwtTokenProvider {
 
     private static final int UNAUTHORIZED = 401;
     private static final long TOKEN_VALID_MILLI_SECONDS =1000L*60*60; //1시간
-
     private static final int COOKIE_VALID_SECONDS = 60*60*24; //24시간
 
 

--- a/src/main/java/com/codeit/todo/common/config/PasswordEncoderConfig.java
+++ b/src/main/java/com/codeit/todo/common/config/PasswordEncoderConfig.java
@@ -1,0 +1,14 @@
+package com.codeit.todo.common.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Configuration
+public class PasswordEncoderConfig {
+    @Bean
+    public PasswordEncoder passwordEncoder(){
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/src/main/java/com/codeit/todo/common/config/SecurityConfig.java
+++ b/src/main/java/com/codeit/todo/common/config/SecurityConfig.java
@@ -24,6 +24,7 @@ public class SecurityConfig {
             .httpBasic(AbstractHttpConfigurer::disable)
             .authorizeHttpRequests(authorizeRequests ->
                 authorizeRequests
+                        .requestMatchers("/signup").permitAll()
                     .requestMatchers("/login").permitAll()
                     .requestMatchers("/swagger-ui/**").permitAll()
                     .requestMatchers("/**").permitAll()

--- a/src/main/java/com/codeit/todo/common/exception/user/SignUpException.java
+++ b/src/main/java/com/codeit/todo/common/exception/user/SignUpException.java
@@ -1,0 +1,13 @@
+package com.codeit.todo.common.exception.user;
+
+import com.codeit.todo.common.exception.ApplicationException;
+import com.codeit.todo.common.exception.payload.ErrorStatus;
+
+public class SignUpException extends ApplicationException {
+    /**
+     * @param errorStatus 상태 코드, 메세지, 발생시간을 저장한 객체
+     */
+    public SignUpException(ErrorStatus errorStatus) {
+        super(errorStatus);
+    }
+}

--- a/src/main/java/com/codeit/todo/domain/User.java
+++ b/src/main/java/com/codeit/todo/domain/User.java
@@ -2,6 +2,7 @@ package com.codeit.todo.domain;
 
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -14,6 +15,10 @@ public class User {
     @Column(name="user_id")
     private int userId;
 
+    @Column(name= "name", nullable = false)
+    private String name;
+
+
     @Column(name= "email", nullable = false)
     private String email;
 
@@ -21,4 +26,11 @@ public class User {
     private String password;
 
 
+    @Builder
+    public User(int userId, String name, String email, String password) {
+        this.userId = userId;
+        this.name = name;
+        this.email = email;
+        this.password = password;
+    }
 }

--- a/src/main/java/com/codeit/todo/service/user/UserService.java
+++ b/src/main/java/com/codeit/todo/service/user/UserService.java
@@ -1,8 +1,13 @@
 package com.codeit.todo.service.user;
 
 import com.codeit.todo.web.dto.request.auth.LoginRequest;
+import com.codeit.todo.web.dto.request.auth.SignUpRequest;
+import com.codeit.todo.web.dto.response.auth.SignUpResponse;
 
 public interface UserService {
 
+    SignUpResponse signUpUser(SignUpRequest signUpRequest);
+
     String login(LoginRequest loginRequest);
+
 }

--- a/src/main/java/com/codeit/todo/service/user/impl/UserServiceImpl.java
+++ b/src/main/java/com/codeit/todo/service/user/impl/UserServiceImpl.java
@@ -3,11 +3,14 @@ package com.codeit.todo.service.user.impl;
 import com.codeit.todo.common.config.JwtTokenProvider;
 import com.codeit.todo.common.exception.ApplicationException;
 import com.codeit.todo.common.exception.payload.ErrorStatus;
+import com.codeit.todo.common.exception.user.SignUpException;
 import com.codeit.todo.common.exception.user.UserNotFoundException;
 import com.codeit.todo.domain.User;
 import com.codeit.todo.repository.UserRepository;
 import com.codeit.todo.service.user.UserService;
 import com.codeit.todo.web.dto.request.auth.LoginRequest;
+import com.codeit.todo.web.dto.request.auth.SignUpRequest;
+import com.codeit.todo.web.dto.response.auth.SignUpResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -16,6 +19,7 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
+import java.security.SignatureException;
 import java.time.LocalDateTime;
 
 @Service
@@ -24,7 +28,31 @@ public class UserServiceImpl implements UserService {
     private final UserRepository userRepository;
     private final AuthenticationManager authenticationManager;
     private final JwtTokenProvider jwtTokenProvider;
+    private final PasswordEncoder passwordEncoder;
 
+    private static final int CONFLICT = 409;
+
+    private static final int BAD_REQUEST = 400;
+
+    @Override
+    public SignUpResponse signUpUser(SignUpRequest request) {
+        //기존에 있는 이메일인지 확인
+        String email = request.email();
+        if(userRepository.findByEmail(email).isPresent()) throw new SignUpException(ErrorStatus.toErrorStatus("이미 존재하는 이메일입니다", CONFLICT));
+
+        //비밀번호, 비밀번호 확인이 일치하는지 확인
+        String password = request.password();
+        String passwordCheck = request.passwordCheck();
+        if(!password.equals(passwordCheck)) throw new SignUpException(ErrorStatus.toErrorStatus("비밀번호가 일치하지 않습니다", BAD_REQUEST));
+
+        //비밀번호 암호화
+        String encodedPassword = passwordEncoder.encode(password);
+
+        User user = request.toEntity(encodedPassword);
+        User savedUser = userRepository.save(user);
+
+        return new SignUpResponse(savedUser.getUserId());
+    }
 
 
     public String login(LoginRequest loginRequest){
@@ -48,5 +76,6 @@ public class UserServiceImpl implements UserService {
             ));
         }
     }
+
 
 }

--- a/src/main/java/com/codeit/todo/web/controller/AuthController.java
+++ b/src/main/java/com/codeit/todo/web/controller/AuthController.java
@@ -3,6 +3,7 @@ package com.codeit.todo.web.controller;
 import com.codeit.todo.common.config.JwtTokenProvider;
 import com.codeit.todo.service.user.UserService;
 import com.codeit.todo.web.dto.request.auth.LoginRequest;
+import com.codeit.todo.web.dto.request.auth.SignUpRequest;
 import com.codeit.todo.web.dto.response.Response;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -10,6 +11,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -22,6 +24,16 @@ public class AuthController {
 
     private final UserService userService;
     private final JwtTokenProvider jwtTokenProvider;
+
+    @Transactional
+    @Operation(summary = "회원가입", description = "이름, 이메일, 비밀번호로 회원가입")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "회원가입 성공")
+    })
+    @PostMapping(value = "/signup")
+    public Response signUp(@RequestBody SignUpRequest signUpRequest){
+        return Response.ok( userService.signUpUser(signUpRequest));
+    }
 
     @Operation(summary = "로그인", description = "이메일과 비밀번호를 받아 로그인 진행")
     @ApiResponses(value = {

--- a/src/main/java/com/codeit/todo/web/dto/request/auth/SignUpRequest.java
+++ b/src/main/java/com/codeit/todo/web/dto/request/auth/SignUpRequest.java
@@ -1,0 +1,28 @@
+package com.codeit.todo.web.dto.request.auth;
+
+
+import com.codeit.todo.domain.Goal;
+import com.codeit.todo.domain.User;
+import jakarta.validation.constraints.NotNull;
+
+import java.time.LocalDateTime;
+
+public record SignUpRequest(
+        @NotNull
+        String name,
+        @NotNull
+        String email,
+        @NotNull
+        String password,
+        @NotNull
+        String passwordCheck) {
+
+    public User toEntity(String encodedPassword) {
+        return User.builder()
+                .name(this.name)
+                .email(this.email)
+                .password(encodedPassword)
+                .build();
+    }
+
+}

--- a/src/main/java/com/codeit/todo/web/dto/response/auth/SignUpResponse.java
+++ b/src/main/java/com/codeit/todo/web/dto/response/auth/SignUpResponse.java
@@ -1,0 +1,8 @@
+package com.codeit.todo.web.dto.response.auth;
+
+import com.codeit.todo.domain.Goal;
+import com.codeit.todo.web.dto.response.goal.CreateGoalResponse;
+import lombok.Builder;
+
+@Builder
+public record SignUpResponse(int userId ) { }

--- a/src/main/java/com/codeit/todo/web/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/codeit/todo/web/filter/JwtAuthenticationFilter.java
@@ -72,7 +72,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
      */
     @Override
     protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
-        String[] excludedPaths = {"/api/v1/auths/login", "/v3/**", "/swagger-ui/**"};
+        String[] excludedPaths = {"/api/v1/auths/signup", "/api/v1/auths/login", "/v3/**", "/swagger-ui/**"};
         AntPathMatcher antPathMatcher = new AntPathMatcher();
 
         for (String excludedPath : excludedPaths) {


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

- close #60

## 📝작업 내용

> 유저의 이름, 이메일, 비밀번호를 받아 회원가입을 합니다. 
- DB의 유저 1, 2 비밀번호 관련하여, 이제 `password encoder`이 있어 기존 비밀번호 `{noop}1234`로는 작동하지 않아 인코딩한 값으로 바꿔두었습니다. 

### 스크린샷 (선택)
<img width="605" alt="Screenshot 2024-12-12 at 23 59 10" src="https://github.com/user-attachments/assets/f3eda261-63ba-49e3-8ebc-3178099411ff" />

## 💬리뷰 요구사항(선택)

- `비밀번호`, `비밀번호 확인`이 일치하는지는 프론트에서도 하시겠지만, 혹시 몰라서 확인하는 코드 추가했습니다. 