### PR TITLE
feat : 오늘 할 일 진행상황 조회하는 API 생성

### DIFF
--- a/src/main/java/com/codeit/todo/domain/Complete.java
+++ b/src/main/java/com/codeit/todo/domain/Complete.java
@@ -8,6 +8,7 @@ import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.Objects;
 
 @Entity
 @Getter
@@ -19,7 +20,7 @@ public class Complete {
     private int completeId;
 
     @Column(nullable = false)
-    private LocalDate completedDate;
+    private LocalDate startDate;
 
     @Column(nullable = false)
     private LocalDateTime createdAt;
@@ -29,15 +30,16 @@ public class Complete {
     private String completeLink;
     private String completeFile;
     private String completePic;
-    private Boolean completeStatus;
+    @Column(nullable = false)
+    private String completeStatus;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "todo_id", nullable = false)
     private Todo todo;
 
     @Builder
-    public Complete(LocalDate completedDate, LocalDateTime createdAt, String note, String completeLink, String completeFile, String completePic, Boolean completeStatus, Todo todo) {
-        this.completedDate = completedDate;
+    public Complete(LocalDate startDate, LocalDateTime createdAt, String note, String completeLink, String completeFile, String completePic, String completeStatus, Todo todo) {
+        this.startDate = startDate;
         this.createdAt = createdAt;
         this.note = note;
         this.completeLink = completeLink;
@@ -52,6 +54,8 @@ public class Complete {
         this.completeFile = completeFileUrl;
         this.completeLink = link;
         this.note = note;
-        this.completeStatus = true;
+        if (Objects.nonNull(completePicUrl) && !completeFileUrl.isEmpty()) {
+            this.completeStatus = "인증";
+        }
     }
 }

--- a/src/main/java/com/codeit/todo/repository/TodoRepository.java
+++ b/src/main/java/com/codeit/todo/repository/TodoRepository.java
@@ -5,6 +5,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.LocalDate;
 import java.util.List;
 
 public interface TodoRepository extends JpaRepository<Todo, Integer> {
@@ -15,4 +16,6 @@ public interface TodoRepository extends JpaRepository<Todo, Integer> {
     Slice<Todo> findByGoal_GoalIdOrderByTodoIdDesc(int goalId, Pageable pageable);
 
     Slice<Todo> findByGoal_GoalIdAndTodoIdLessThanOrderByTodoIdDesc(int goalId, Integer lastTodoId, Pageable pageable);
+
+    List<Todo> findByGoal_GoalIdInAndStartDate(List<Integer> goalIds, LocalDate today);
 }

--- a/src/main/java/com/codeit/todo/service/todo/TodoService.java
+++ b/src/main/java/com/codeit/todo/service/todo/TodoService.java
@@ -3,10 +3,7 @@ package com.codeit.todo.service.todo;
 import com.codeit.todo.web.dto.request.todo.CreateTodoRequest;
 import com.codeit.todo.web.dto.request.todo.ReadTodoRequest;
 import com.codeit.todo.web.dto.request.todo.ReadTodoWithGoalRequest;
-import com.codeit.todo.web.dto.response.todo.CreateTodoResponse;
-import com.codeit.todo.web.dto.response.todo.ReadTodoWithGoalResponse;
-import com.codeit.todo.web.dto.response.todo.ReadTodosResponse;
-import com.codeit.todo.web.dto.response.todo.ReadTodosWithGoalsResponse;
+import com.codeit.todo.web.dto.response.todo.*;
 import org.springframework.data.domain.Slice;
 
 import java.util.List;
@@ -20,4 +17,6 @@ public interface TodoService {
     List<ReadTodosWithGoalsResponse> findTodoListWithGoals(int userId, ReadTodoWithGoalRequest request);
 
     Slice<ReadTodoWithGoalResponse> findTodoListWithGoal(int userId, int goalId, ReadTodoWithGoalRequest request);
+
+    ReadTodoProgressResponse calculateTodoProgress(int userId);
 }

--- a/src/main/java/com/codeit/todo/service/todo/impl/TodoServiceImpl.java
+++ b/src/main/java/com/codeit/todo/service/todo/impl/TodoServiceImpl.java
@@ -15,6 +15,7 @@ import com.codeit.todo.web.dto.request.todo.ReadTodoWithGoalRequest;
 import com.codeit.todo.web.dto.response.complete.ReadCompleteResponse;
 import com.codeit.todo.web.dto.response.todo.*;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -29,6 +30,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional
@@ -221,6 +223,7 @@ public class TodoServiceImpl implements TodoService {
 
         double progress = totalTodos > 0 ? (double) completedTodo / totalTodos * 100 : 0;
 
+        log.info("할 일 진행상황 조회 성공 : {}", totalTodos);
         return ReadTodoProgressResponse.from(progress);
     }
 }

--- a/src/main/java/com/codeit/todo/web/controller/TodoController.java
+++ b/src/main/java/com/codeit/todo/web/controller/TodoController.java
@@ -6,10 +6,7 @@ import com.codeit.todo.web.dto.request.todo.CreateTodoRequest;
 import com.codeit.todo.web.dto.request.todo.ReadTodoRequest;
 import com.codeit.todo.web.dto.request.todo.ReadTodoWithGoalRequest;
 import com.codeit.todo.web.dto.response.Response;
-import com.codeit.todo.web.dto.response.todo.CreateTodoResponse;
-import com.codeit.todo.web.dto.response.todo.ReadTodoWithGoalResponse;
-import com.codeit.todo.web.dto.response.todo.ReadTodosResponse;
-import com.codeit.todo.web.dto.response.todo.ReadTodosWithGoalsResponse;
+import com.codeit.todo.web.dto.response.todo.*;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
@@ -91,6 +88,21 @@ public class TodoController {
     ) {
         int userId = userDetails.getUserId();
         return Response.ok(todoService.saveTodo(userId, request));
+    }
+
+    @Operation(
+            summary = "오늘 할 일 진행상황 조회",
+            description = "오늘 할 일 진행상황을 조회하는 API 입니다. '인증된 할 일 / 전체 할 일'으로 계산되며 double 값이 반환됩니다."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "조회 성공")
+    })
+    @GetMapping("/progress")
+    public Response<ReadTodoProgressResponse> getTodoProgress(
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        int userId = userDetails.getUserId();
+        return Response.ok(todoService.calculateTodoProgress(userId));
     }
 
 }

--- a/src/main/java/com/codeit/todo/web/dto/response/todo/ReadTodoProgressResponse.java
+++ b/src/main/java/com/codeit/todo/web/dto/response/todo/ReadTodoProgressResponse.java
@@ -1,0 +1,12 @@
+package com.codeit.todo.web.dto.response.todo;
+
+import lombok.Builder;
+
+@Builder
+public record ReadTodoProgressResponse(double progress) {
+    public static ReadTodoProgressResponse from(double progress) {
+        return ReadTodoProgressResponse.builder()
+                .progress(progress)
+                .build();
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

- close #80 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

~~- 오늘 할 일 진행상황 조회하는 기능입니다. 인증된 할 일 / 전체 할 일로 계산됩니다~~
- 오늘 날짜와 일치하는 Complete만 필터링하도록 로직 수정
- Complete의 상태가 특정값(인증, 진행)일 때만 계산되도록 개선

### 스크린샷 (선택)

아무것도 하지 않았을 경우

![image](https://github.com/user-attachments/assets/3638b088-49e9-4101-b4d7-aa95cc0f2316)

오늘 해야될 인증 2개 중 1개만 인증한 경우

![image](https://github.com/user-attachments/assets/de6c4c24-0a50-4fcc-a81b-625ab66927bd)


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메소드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?