### PR TITLE
fix:  목표 생성 시 유저 아이디 받지 않기, 색상 값 바꾸기

### DIFF
--- a/src/main/java/com/codeit/todo/service/goal/impl/GoalServiceImpl.java
+++ b/src/main/java/com/codeit/todo/service/goal/impl/GoalServiceImpl.java
@@ -53,7 +53,7 @@ public class GoalServiceImpl implements GoalService {
     @Transactional
     @Override
     public CreateGoalResponse saveGoal(int userId, CreateGoalRequest request) {
-        String[] colors= {"orange", "pink", "purple", "blue", "red"};
+        String[] colors= {"#FFAB76", "#F49696", "#B18AE0", "#A8D8F0", "#FFEC8B"};
         Random random = new Random();
         String color = colors[random.nextInt(colors.length)];
 

--- a/src/main/java/com/codeit/todo/web/dto/request/goal/CreateGoalRequest.java
+++ b/src/main/java/com/codeit/todo/web/dto/request/goal/CreateGoalRequest.java
@@ -8,8 +8,7 @@ import java.time.LocalDateTime;
 
 public record CreateGoalRequest (
         @NotNull
-        String title,
-        int userId
+        String title
 ) {
 
     public Goal toEntity(String color, User user) {


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

- close #87 

## 📝작업 내용

> 목표 생성 시 유저 아이디 받지 않도록 DTO를 수정
> 색상값을 기존 "orange"에서 "#F49696" 색상코드로 수정

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메소드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?