### PR TITLE
feat: 쿠키에 도메인 추가

### DIFF
--- a/src/main/java/com/codeit/todo/web/controller/AuthController.java
+++ b/src/main/java/com/codeit/todo/web/controller/AuthController.java
@@ -52,6 +52,7 @@ public class AuthController {
                 .path("/")
                 .maxAge(COOKIE_VALID_SECONDS)
                 .sameSite("None")
+                .domain(".vercel.app")
                 .build();
 
         return ResponseEntity.ok()


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

- close #100 

## 📝작업 내용

- 쿠키에 "vercel.app" 도메인을 추가합니다. 
- response cookie를 사용하고 있기 때문에 "."추가가 문제없이 가능했습니다. 
- 다만, *은 와일드카드로 사용이 불가능하다고 합니다. 
- 쿠키 도메인 추가 후 로컬에서는 토큰을 요구하는 다른 기능들(목표 CRUD 등)이 불가능해졌습니다. 

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메소드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?