### PR TITLE
feat: ResponseCookie 만드는 코드 jwtTokenProvider로 옮기기

### DIFF
--- a/src/main/java/com/codeit/todo/common/config/JwtTokenProvider.java
+++ b/src/main/java/com/codeit/todo/common/config/JwtTokenProvider.java
@@ -25,7 +25,9 @@ public class JwtTokenProvider {
 
     private static final int UNAUTHORIZED = 401;
     private static final long TOKEN_VALID_MILLI_SECONDS =1000L*60*60; //1시간
+    private static final int COOKIE_VALID_SECONDS = 60*60*24; //24시간
 
+    
 
     @Value("${jwtpassword.source}")
     private String secretKeySource;
@@ -99,4 +101,15 @@ public class JwtTokenProvider {
     }
 
 
+    public ResponseCookie createResponseCookie(String token) {
+        ResponseCookie cookie = ResponseCookie.from("token", token)
+                .httpOnly(true)
+                .secure(true)
+                .path("/")
+                .maxAge(COOKIE_VALID_SECONDS)
+                .sameSite("None")
+                .domain(".solidtodo.shop")
+                .build();
+        return cookie;
+    }
 }

--- a/src/main/java/com/codeit/todo/web/controller/AuthController.java
+++ b/src/main/java/com/codeit/todo/web/controller/AuthController.java
@@ -26,7 +26,7 @@ import org.springframework.web.bind.annotation.*;
 public class AuthController {
 
     private final UserService userService;
-    private static final int COOKIE_VALID_SECONDS = 60*60*24; //24시간
+    private final JwtTokenProvider jwtTokenProvider;
 
 
     @Transactional
@@ -46,14 +46,7 @@ public class AuthController {
     @PostMapping(value = "/login")
     public ResponseEntity<String> login(@RequestBody LoginRequest loginRequest){
         String token = userService.login(loginRequest);
-        ResponseCookie cookie = ResponseCookie.from("token", token)
-                .httpOnly(true)
-                .secure(true)
-                .path("/")
-                .maxAge(COOKIE_VALID_SECONDS)
-                .sameSite("None")
-                .domain(".solidtodo.shop")
-                .build();
+        ResponseCookie cookie = jwtTokenProvider.createResponseCookie(token);
 
         return ResponseEntity.ok()
                 .header(HttpHeaders.SET_COOKIE, cookie.toString())


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

- close #103

## 📝작업 내용

> 쿠키를 생성하는 메소드를 JwtTokenProvider로 옮겼습니다. 
> authController에서는 최소한의 메소드만 처리하게 하고 코드를 짧게 수정했습니다. 

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메소드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?