### PR TITLE
refactor : 오늘 할일 응답 필드 추가/ 조회 시, 시작날짜와 끝날짜 사이에 있는 할일을 찾아오도록 개선

### DIFF
--- a/src/main/java/com/codeit/todo/repository/TodoRepository.java
+++ b/src/main/java/com/codeit/todo/repository/TodoRepository.java
@@ -4,6 +4,8 @@ import com.codeit.todo.domain.Todo;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -17,5 +19,6 @@ public interface TodoRepository extends JpaRepository<Todo, Integer> {
 
     Slice<Todo> findByGoal_GoalIdAndTodoIdLessThanOrderByTodoIdDesc(int goalId, Integer lastTodoId, Pageable pageable);
 
-    List<Todo> findByGoal_GoalIdInAndStartDate(List<Integer> goalIds, LocalDate today);
+    @Query("select t from Todo t where t.goal.goalId in :goalIds and :today between t.startDate and t.endDate")
+    List<Todo> findTodosBetweenDates(@Param("goalIds") List<Integer> goalIds, @Param("today") LocalDate today);
 }

--- a/src/main/java/com/codeit/todo/service/todo/impl/TodoServiceImpl.java
+++ b/src/main/java/com/codeit/todo/service/todo/impl/TodoServiceImpl.java
@@ -228,7 +228,7 @@ public class TodoServiceImpl implements TodoService {
                 .map(Goal::getGoalId)
                 .toList();
 
-        return todoRepository.findByGoal_GoalIdInAndStartDate(goalIds, today);
+        return todoRepository.findTodosBetweenDates(goalIds, today);
     }
 
     private List<ReadTodosResponse> getTodoResponses(Slice<Todo> todos) {

--- a/src/main/java/com/codeit/todo/web/dto/response/todo/ReadTodayTodoResponse.java
+++ b/src/main/java/com/codeit/todo/web/dto/response/todo/ReadTodayTodoResponse.java
@@ -7,12 +7,14 @@ import lombok.Builder;
 import java.util.List;
 
 @Builder
-public record ReadTodayTodoResponse(int todoId, String todoTitle, ReadCompleteResponse complete) {
+public record ReadTodayTodoResponse(int todoId, String todoTitle, String goalTitle, String goalColor, ReadCompleteResponse complete) {
     public static ReadTodayTodoResponse from(Todo todo, ReadCompleteResponse todayComplete) {
         return ReadTodayTodoResponse.builder()
                 .todoId(todo.getTodoId())
                 .todoTitle(todo.getTodoTitle())
                 .complete(todayComplete)
+                .goalTitle(todo.getGoal().getGoalTitle())
+                .goalColor(todo.getGoal().getColor())
                 .build();
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

- close #106

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- 프론트 요청으로 응답 필드에 색상, 목표명 추가했습니다.
- 오늘 할일 조회할때 현재는 오늘이 startDate와 일치해야만 해당 할일을 가져왔습니다.
- 따라서, 오늘이 startDate와 endDate 사이에 있다면 그 할일을 가져오도록 개선했습니다.

### 스크린샷 (선택)

![image](https://github.com/user-attachments/assets/07091de8-3d81-41ed-b69f-65d0d2686e94)


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메소드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?