### PR TITLE
feat: 회원 가입 시 기본 프로필 사진 설정 및 유저 정보 불러올 때 이미지 불러오도록 수정

### DIFF
--- a/src/main/java/com/codeit/todo/domain/User.java
+++ b/src/main/java/com/codeit/todo/domain/User.java
@@ -25,12 +25,16 @@ public class User {
     @Column(name= "password", nullable = false)
     private String password;
 
+    @Column(name = "profile_pic", nullable = false)
+    private String profilePic;
+
 
     @Builder
-    public User(int userId, String name, String email, String password) {
+    public User(int userId, String name, String email, String password, String profilePic) {
         this.userId = userId;
         this.name = name;
         this.email = email;
         this.password = password;
+        this.profilePic = profilePic;
     }
 }

--- a/src/main/java/com/codeit/todo/service/user/impl/UserServiceImpl.java
+++ b/src/main/java/com/codeit/todo/service/user/impl/UserServiceImpl.java
@@ -49,7 +49,10 @@ public class UserServiceImpl implements UserService {
         //비밀번호 암호화
         String encodedPassword = passwordEncoder.encode(password);
 
-        User user = request.toEntity(encodedPassword);
+        //회원가입 시 기본 프로필 이미지 등록
+        String profilePic = "https://slid-todo.s3.ap-northeast-2.amazonaws.com/auth/default_profilepic_mouse.png";
+
+        User user = request.toEntity(encodedPassword, profilePic);
         User savedUser = userRepository.save(user);
 
         return new SignUpResponse(savedUser.getUserId());

--- a/src/main/java/com/codeit/todo/web/dto/request/auth/SignUpRequest.java
+++ b/src/main/java/com/codeit/todo/web/dto/request/auth/SignUpRequest.java
@@ -17,11 +17,12 @@ public record SignUpRequest(
         @NotNull
         String passwordCheck) {
 
-    public User toEntity(String encodedPassword) {
+    public User toEntity(String encodedPassword, String profilePic) {
         return User.builder()
                 .name(this.name)
                 .email(this.email)
                 .password(encodedPassword)
+                .profilePic(profilePic)
                 .build();
     }
 

--- a/src/main/java/com/codeit/todo/web/dto/response/auth/ReadUserResponse.java
+++ b/src/main/java/com/codeit/todo/web/dto/response/auth/ReadUserResponse.java
@@ -6,12 +6,14 @@ import lombok.Builder;
 @Builder
 public record ReadUserResponse(
         String name,
-        String email
+        String email,
+        String profilePic
 ) {
     public static ReadUserResponse from(User user){
         return ReadUserResponse.builder()
                 .name(user.getName())
                 .email(user.getEmail())
+                .profilePic(user.getProfilePic())
                 .build();
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

- close #109 

## 📝작업 내용

- 회원 가입 시 기본 프로필 사진을 설정합니다. 
- 매번 똑같은 사진 1개를 불러오니 db또는 S3서버에 갔다오는게 더 비효율적인 것 같아
 사진 URL을 String으로 코드에 고정해서 불러오도록 했습니다. 

- 유저 정보를 불러올 때 이미지도 불러오도록 합니다. 

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메소드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?