### PR TITLE
feat: 유저의 프로필 사진 변경 API

### DIFF
--- a/src/main/java/com/codeit/todo/domain/User.java
+++ b/src/main/java/com/codeit/todo/domain/User.java
@@ -37,4 +37,8 @@ public class User {
         this.password = password;
         this.profilePic = profilePic;
     }
+
+    public void updateProfilePic(String completePicUrl){
+        this.profilePic = completePicUrl;
+    }
 }

--- a/src/main/java/com/codeit/todo/service/user/UserService.java
+++ b/src/main/java/com/codeit/todo/service/user/UserService.java
@@ -2,8 +2,10 @@ package com.codeit.todo.service.user;
 
 import com.codeit.todo.web.dto.request.auth.LoginRequest;
 import com.codeit.todo.web.dto.request.auth.SignUpRequest;
+import com.codeit.todo.web.dto.request.auth.UpdatePictureRequest;
 import com.codeit.todo.web.dto.response.auth.ReadUserResponse;
 import com.codeit.todo.web.dto.response.auth.SignUpResponse;
+import com.codeit.todo.web.dto.response.auth.UpdatePictureResponse;
 
 public interface UserService {
 
@@ -12,4 +14,6 @@ public interface UserService {
     String login(LoginRequest loginRequest);
 
     ReadUserResponse findUserInfo(int userId);
+
+    UpdatePictureResponse updateProfilePicture(int userId, UpdatePictureRequest pictureRequest);
 }

--- a/src/main/java/com/codeit/todo/web/controller/AuthController.java
+++ b/src/main/java/com/codeit/todo/web/controller/AuthController.java
@@ -5,8 +5,12 @@ import com.codeit.todo.repository.CustomUserDetails;
 import com.codeit.todo.service.user.UserService;
 import com.codeit.todo.web.dto.request.auth.LoginRequest;
 import com.codeit.todo.web.dto.request.auth.SignUpRequest;
+import com.codeit.todo.web.dto.request.auth.UpdatePictureRequest;
+import com.codeit.todo.web.dto.request.complete.UpdateCompleteRequest;
 import com.codeit.todo.web.dto.response.Response;
 import com.codeit.todo.web.dto.response.auth.ReadUserResponse;
+import com.codeit.todo.web.dto.response.auth.UpdatePictureResponse;
+import com.codeit.todo.web.dto.response.complete.UpdateCompleteResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
@@ -60,5 +64,22 @@ public class AuthController {
     public Response getUserInfo(@AuthenticationPrincipal CustomUserDetails customUserDetails){
         int userId = customUserDetails.getUserId();
         return Response.ok( userService.findUserInfo(userId) );
+    }
+
+    @Transactional
+    @Operation(
+            summary = "프로필 사진 수정",
+            description = "유저가 원하는 사진을 골라 프로필 사진을 수정"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "수정 성공")
+    })
+    @PutMapping("/profilepic")
+    public Response<UpdatePictureResponse> updateUserProfilePicture(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestBody UpdatePictureRequest pictureRequest
+            ) {
+        int userId = userDetails.getUserId();
+        return Response.ok(userService.updateProfilePicture(userId, pictureRequest));
     }
 }

--- a/src/main/java/com/codeit/todo/web/dto/request/auth/UpdatePictureRequest.java
+++ b/src/main/java/com/codeit/todo/web/dto/request/auth/UpdatePictureRequest.java
@@ -1,0 +1,7 @@
+package com.codeit.todo.web.dto.request.auth;
+
+public record UpdatePictureRequest (
+        String profilePicBase64,
+        String profilePicName
+){
+}

--- a/src/main/java/com/codeit/todo/web/dto/response/auth/UpdatePictureResponse.java
+++ b/src/main/java/com/codeit/todo/web/dto/response/auth/UpdatePictureResponse.java
@@ -1,0 +1,6 @@
+package com.codeit.todo.web.dto.response.auth;
+
+public record UpdatePictureResponse (
+        int userId
+){
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

- close #113 

## 📝작업 내용

- 유저가 원하는 사진을 선택해 프로필 이미지를 바꿀 수 있습니다. 
- 바뀐 이미지는 S3서버에 업로드됩니다. 

### 스크린샷 (선택)

<img width="789" alt="Screenshot 2024-12-22 at 17 59 50" src="https://github.com/user-attachments/assets/d15c0b95-0588-4a06-bb52-9a6d937b0350" />


## 💬리뷰 요구사항(선택)

- 사진들을 많이 업로드하다보면 인증 사진 & 프로필 사진 등등이 섞일 것 같아서, S3서버에 폴더를 추가해 각각에 저장하는건 어떤지 건의합니다. 
예를 들어 S3서버는 이렇게 바꾸고
```JAVA
@Override
public String uploadFile(String folderName, String fileEncodedBase64, String fileName) {
//기존 코드
           String uploadFileName = folderName + UUID.randomUUID() + "_" + fileName;

}
```

프로필 사진을 올리는 서비스에서 

```JAVA
newProfilePicUrl = storageService.uploadFile("profilePic/", pictureRequest.profilePicBase64(), pictureRequest.profilePicName());
```
이런식으로 바꿔봐도 좋을 것 같아요~