### PR TITLE
feat: 검색 기능 구현

### DIFF
--- a/src/main/java/com/codeit/todo/common/config/SecurityConfig.java
+++ b/src/main/java/com/codeit/todo/common/config/SecurityConfig.java
@@ -28,6 +28,7 @@ public class SecurityConfig {
                 authorizeRequests
                         .requestMatchers("/signup").permitAll()
                     .requestMatchers("/login").permitAll()
+                        .requestMatchers("/searches").permitAll()
                     .requestMatchers("/swagger-ui/**").permitAll()
                     .requestMatchers("/**").permitAll()
                         .anyRequest().authenticated()

--- a/src/main/java/com/codeit/todo/common/exception/EntityNotFoundException.java
+++ b/src/main/java/com/codeit/todo/common/exception/EntityNotFoundException.java
@@ -29,4 +29,5 @@ public class EntityNotFoundException extends ApplicationException{
         this.request = request;
         this.entityType = entityType;
     }
+
 }

--- a/src/main/java/com/codeit/todo/common/exception/search/SearchException.java
+++ b/src/main/java/com/codeit/todo/common/exception/search/SearchException.java
@@ -1,0 +1,13 @@
+package com.codeit.todo.common.exception.search;
+
+import com.codeit.todo.common.exception.ApplicationException;
+import com.codeit.todo.common.exception.payload.ErrorStatus;
+
+public class SearchException extends ApplicationException {
+    /**
+     * @param errorStatus 상태 코드, 메세지, 발생시간을 저장한 객체
+     */
+    public SearchException(ErrorStatus errorStatus) {
+        super(errorStatus);
+    }
+}

--- a/src/main/java/com/codeit/todo/domain/User.java
+++ b/src/main/java/com/codeit/todo/domain/User.java
@@ -31,6 +31,9 @@ public class User {
     @Column(name = "profile_pic", nullable = false)
     private String profilePic;
 
+    @OneToMany(mappedBy= "user", cascade = CascadeType.REMOVE, orphanRemoval = true)
+    private List<Goal> goals = new ArrayList<>();
+
     //나를 팔로우 하는 사람들
     @OneToMany(mappedBy = "followee", cascade = CascadeType.REMOVE, orphanRemoval = true)
     private List<Follow> followers = new ArrayList<>();

--- a/src/main/java/com/codeit/todo/domain/enums/SearchField.java
+++ b/src/main/java/com/codeit/todo/domain/enums/SearchField.java
@@ -1,0 +1,16 @@
+package com.codeit.todo.domain.enums;
+
+import lombok.Getter;
+
+@Getter
+public enum SearchField {
+    USER_NAME("유저명"),
+    GOAL_TITLE("목표명");
+
+    private final String value;
+
+    SearchField(String value){
+        this.value = value;
+    }
+
+}

--- a/src/main/java/com/codeit/todo/repository/GoalRepository.java
+++ b/src/main/java/com/codeit/todo/repository/GoalRepository.java
@@ -38,4 +38,6 @@ and g.goalId = :lastGoalId
 and :today between t.startDate and t.endDate
 """)
     Slice<Goal> findByUserAndHasTodosAfterLastGoalId(@Param("lastGoalId") Integer lastGoalId, @Param("userId") int userId, Pageable pageable,  @Param("today") LocalDate today);
+
+    List<Goal> findByGoalTitleContains(@Param("keyword") String keyword);
 }

--- a/src/main/java/com/codeit/todo/repository/UserRepository.java
+++ b/src/main/java/com/codeit/todo/repository/UserRepository.java
@@ -3,9 +3,12 @@ package com.codeit.todo.repository;
 
 import com.codeit.todo.domain.Todo;
 import com.codeit.todo.domain.User;
+import io.lettuce.core.dynamic.annotation.Param;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -13,4 +16,6 @@ public interface UserRepository extends JpaRepository<User, Integer> {
 
 
     Optional<User> findByEmail(String email);
+
+    List<User> findByNameContains(@Param("keyword") String keyword);
 }

--- a/src/main/java/com/codeit/todo/service/search/SearchService.java
+++ b/src/main/java/com/codeit/todo/service/search/SearchService.java
@@ -1,0 +1,10 @@
+package com.codeit.todo.service.search;
+
+import com.codeit.todo.web.dto.request.search.ReadSearchRequest;
+import com.codeit.todo.web.dto.response.search.ReadSearchResponse;
+
+import java.util.List;
+
+public interface SearchService {
+    List<ReadSearchResponse> findUserAndGoal(ReadSearchRequest request);
+}

--- a/src/main/java/com/codeit/todo/service/search/impl/SearchServiceImpl.java
+++ b/src/main/java/com/codeit/todo/service/search/impl/SearchServiceImpl.java
@@ -1,0 +1,85 @@
+package com.codeit.todo.service.search.impl;
+
+import com.codeit.todo.common.exception.EntityNotFoundException;
+import com.codeit.todo.common.exception.goal.GoalNotFoundException;
+import com.codeit.todo.common.exception.payload.ErrorStatus;
+import com.codeit.todo.common.exception.search.SearchException;
+import com.codeit.todo.common.exception.user.UserNotFoundException;
+import com.codeit.todo.domain.Goal;
+import com.codeit.todo.domain.User;
+import com.codeit.todo.domain.enums.SearchField;
+import com.codeit.todo.repository.GoalRepository;
+import com.codeit.todo.repository.UserRepository;
+import com.codeit.todo.service.search.SearchService;
+import com.codeit.todo.web.dto.request.search.ReadSearchRequest;
+import com.codeit.todo.web.dto.response.goal.ReadGoalSearchResponse;
+import com.codeit.todo.web.dto.response.search.ReadSearchResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class SearchServiceImpl implements SearchService {
+    private final UserRepository userRepository;
+    private final GoalRepository goalRepository;
+
+    private static final int BAD_REQUEST = 400;
+
+    private static final int NOT_FOUND = 404;
+
+    @Override
+    public List<ReadSearchResponse> findUserAndGoal(ReadSearchRequest request) {
+        String searchField = request.searchField();
+        String keyword = request.keyword();
+
+        log.info("Starting search for field: {} with keyword: {}", searchField, keyword);
+
+        if( searchField.equals(SearchField.USER_NAME.getValue()) ){
+            List<User> searchedUsers = userRepository.findByNameContains(keyword);
+            if(searchedUsers.isEmpty()) throw new SearchException(ErrorStatus.toErrorStatus("유저에 대한 검색 결과가 없습니다.", NOT_FOUND));
+
+            List<ReadSearchResponse> responses = searchedUsers.stream()
+                    .map(user -> {
+                        List<Goal> goals = user.getGoals();
+                        List<ReadGoalSearchResponse> goalsResponses = goals.stream()
+                                .map(ReadGoalSearchResponse::from)
+                                .toList();
+
+                        return ReadSearchResponse.from(user, goalsResponses);
+                    }).toList();
+            return responses;
+
+        }else if(searchField.equals(SearchField.GOAL_TITLE.getValue())){
+            List<Goal> searchedGoals = goalRepository.findByGoalTitleContains(keyword);
+            if(searchedGoals.isEmpty()) throw new SearchException(ErrorStatus.toErrorStatus("목표에 대한 검색 결과가 없습니다.", NOT_FOUND));
+
+            Map<User, List<Goal>> userGoalsMap = searchedGoals.stream()
+                    .collect(Collectors.groupingBy(Goal::getUser));
+
+            List<ReadSearchResponse> responses = userGoalsMap.entrySet().stream()
+                    .map(entry -> {
+                        User user = entry.getKey();
+                        List<Goal> goals = entry.getValue();
+
+                        List<ReadGoalSearchResponse> goalsResponses = goals.stream()
+                                .map(ReadGoalSearchResponse::from)
+                                .toList();
+
+                        return ReadSearchResponse.from(user, goalsResponses);
+
+                    }).toList();
+            return responses;
+        }else{
+            throw new SearchException(ErrorStatus.toErrorStatus("해당 필드로는 검색할 수 없습니다", BAD_REQUEST));
+        }
+    }
+}

--- a/src/main/java/com/codeit/todo/web/controller/SearchController.java
+++ b/src/main/java/com/codeit/todo/web/controller/SearchController.java
@@ -1,0 +1,39 @@
+package com.codeit.todo.web.controller;
+
+import com.codeit.todo.repository.CustomUserDetails;
+
+import com.codeit.todo.service.search.SearchService;
+import com.codeit.todo.web.dto.request.search.ReadSearchRequest;
+import com.codeit.todo.web.dto.response.Response;
+import com.codeit.todo.web.dto.response.search.ReadSearchResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/searches")
+public class SearchController {
+
+    private final SearchService searchService;
+
+    @Operation(summary = "유저 또는 목표 검색", description = "유저 또는 목표를 검색하고 유저와 목표를 함께 반환합니다")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "검색 성공")
+    })
+    @GetMapping
+    public Response<List<ReadSearchResponse>> getSearch(
+            @Valid @RequestBody ReadSearchRequest request
+            ){
+        return Response.ok(searchService.findUserAndGoal(request));
+    }
+}

--- a/src/main/java/com/codeit/todo/web/dto/request/search/ReadSearchRequest.java
+++ b/src/main/java/com/codeit/todo/web/dto/request/search/ReadSearchRequest.java
@@ -1,0 +1,13 @@
+package com.codeit.todo.web.dto.request.search;
+
+import jakarta.validation.constraints.NotNull;
+
+public record ReadSearchRequest(
+        @NotNull
+        String searchField,
+
+        @NotNull
+        String keyword
+) {
+
+}

--- a/src/main/java/com/codeit/todo/web/dto/response/goal/ReadGoalSearchResponse.java
+++ b/src/main/java/com/codeit/todo/web/dto/response/goal/ReadGoalSearchResponse.java
@@ -1,0 +1,22 @@
+package com.codeit.todo.web.dto.response.goal;
+
+import com.codeit.todo.domain.Goal;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+
+@Builder
+public record ReadGoalSearchResponse(
+        int goalId,
+        String goalTitle,
+        String color
+
+) {
+    public static ReadGoalSearchResponse from(Goal goal){
+        return ReadGoalSearchResponse.builder()
+                .goalId(goal.getGoalId())
+                .goalTitle(goal.getGoalTitle())
+                .color(goal.getColor())
+                .build();
+    }
+}

--- a/src/main/java/com/codeit/todo/web/dto/response/search/ReadSearchResponse.java
+++ b/src/main/java/com/codeit/todo/web/dto/response/search/ReadSearchResponse.java
@@ -1,0 +1,23 @@
+package com.codeit.todo.web.dto.response.search;
+
+import com.codeit.todo.domain.User;
+import com.codeit.todo.web.dto.response.goal.ReadGoalSearchResponse;
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+public record ReadSearchResponse (
+        String name,
+        String profilePic,
+
+        List<ReadGoalSearchResponse> goals
+){
+    public static ReadSearchResponse from(User user, List<ReadGoalSearchResponse> responses) {
+        return ReadSearchResponse.builder()
+                .name(user.getName())
+                .profilePic(user.getProfilePic())
+                .goals(responses)
+                .build();
+    }
+}

--- a/src/main/java/com/codeit/todo/web/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/codeit/todo/web/filter/JwtAuthenticationFilter.java
@@ -76,7 +76,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
      */
     @Override
     protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
-        String[] excludedPaths = {"/api/v1/auths/signup", "/api/v1/auths/login", "/v3/**", "/swagger-ui/**"};
+        String[] excludedPaths = {"/api/v1/auths/signup", "/api/v1/auths/login", "/api/v1/searches", "/v3/**", "/swagger-ui/**"};
         AntPathMatcher antPathMatcher = new AntPathMatcher();
 
         for (String excludedPath : excludedPaths) {


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

- close #129 

## 📝작업 내용

- 유저 또는 목표 검색 필드와 검색하는 키워드를 받아 검색합니다. 
- 검색어의 경우 유저는 유저 이름 중에서, 목표는 목표 제목에 포함되었는지 검색합니다. 이는 JPA 네이밍으로 쉽게 해결했습니다.
- 두 경우 모두 같은 결과(유저 + 목표)를 반환합니다. (디자인 변경이 필요할 것 같습니다)
- 유저로 검색해서 목표를 받아오는 검색은 별로 문제가 없었는데, 
목표로 검색하는 경우 검색어가 포함된 목표가 여러개가 있으면 유저와 목표를 여러번 반환하는 문제가 있었습니다. 
그래서 `Map`을 사용해 검색 결과 목표가 여러개더라도 유저가 같으면 한 번만 반환하도록 하였습니다. 
- 저희가 검색하기로 한 테이블이 `유저명`, `목표명` 으로 딱 두 개라서 `enum`을 사용해 안정성을 높였습니다. 

### 스크린샷 (선택)
<img width="790" alt="Screenshot 2024-12-26 at 00 58 50" src="https://github.com/user-attachments/assets/7cb65bfc-643f-4941-9591-be3d52ec32c8" />


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메소드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?