### PR TITLE
feat: 타인 프로필 페이지 구현

### DIFF
--- a/src/main/java/com/codeit/todo/repository/FollowRepository.java
+++ b/src/main/java/com/codeit/todo/repository/FollowRepository.java
@@ -1,0 +1,21 @@
+package com.codeit.todo.repository;
+
+import com.codeit.todo.domain.Follow;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface FollowRepository extends JpaRepository<Follow, Integer> {
+
+    @Query(
+            "SELECT COUNT(f) > 0 " +
+                    "from Follow f " +
+                    "WHERE f.followee.userId = :userId " +
+                    "AND f.follower.userId = :targetUserId "
+    )
+    boolean existsByFollower_FollowerIdAndFollowee_FolloweeId(@Param("userId")int userId, @Param("targetUserId")int targetUserId);
+
+}
+

--- a/src/main/java/com/codeit/todo/service/user/UserService.java
+++ b/src/main/java/com/codeit/todo/service/user/UserService.java
@@ -4,10 +4,7 @@ import com.codeit.todo.web.dto.request.auth.LoginRequest;
 import com.codeit.todo.web.dto.request.auth.SignUpRequest;
 import com.codeit.todo.web.dto.request.auth.UpdatePasswordRequest;
 import com.codeit.todo.web.dto.request.auth.UpdatePictureRequest;
-import com.codeit.todo.web.dto.response.auth.ReadUserResponse;
-import com.codeit.todo.web.dto.response.auth.SignUpResponse;
-import com.codeit.todo.web.dto.response.auth.UpdatePasswordResponse;
-import com.codeit.todo.web.dto.response.auth.UpdatePictureResponse;
+import com.codeit.todo.web.dto.response.auth.*;
 
 public interface UserService {
 
@@ -20,4 +17,6 @@ public interface UserService {
     UpdatePictureResponse updateProfilePicture(int userId, UpdatePictureRequest pictureRequest);
 
     UpdatePasswordResponse updatePassword(int userId, UpdatePasswordRequest passwordRequest);
+
+    ReadTargetUserResponse findTargetUserProfile(int userId, int targetUserId);
 }

--- a/src/main/java/com/codeit/todo/service/user/impl/UserServiceImpl.java
+++ b/src/main/java/com/codeit/todo/service/user/impl/UserServiceImpl.java
@@ -6,7 +6,12 @@ import com.codeit.todo.common.exception.payload.ErrorStatus;
 import com.codeit.todo.common.exception.user.SignUpException;
 import com.codeit.todo.common.exception.user.UpdatePasswordException;
 import com.codeit.todo.common.exception.user.UserNotFoundException;
+import com.codeit.todo.domain.Complete;
+import com.codeit.todo.domain.Todo;
 import com.codeit.todo.domain.User;
+import com.codeit.todo.repository.CompleteRepository;
+import com.codeit.todo.repository.FollowRepository;
+import com.codeit.todo.repository.GoalRepository;
 import com.codeit.todo.repository.UserRepository;
 import com.codeit.todo.service.storage.StorageService;
 import com.codeit.todo.service.user.UserService;
@@ -14,10 +19,8 @@ import com.codeit.todo.web.dto.request.auth.LoginRequest;
 import com.codeit.todo.web.dto.request.auth.SignUpRequest;
 import com.codeit.todo.web.dto.request.auth.UpdatePasswordRequest;
 import com.codeit.todo.web.dto.request.auth.UpdatePictureRequest;
-import com.codeit.todo.web.dto.response.auth.ReadUserResponse;
-import com.codeit.todo.web.dto.response.auth.SignUpResponse;
-import com.codeit.todo.web.dto.response.auth.UpdatePasswordResponse;
-import com.codeit.todo.web.dto.response.auth.UpdatePictureResponse;
+import com.codeit.todo.web.dto.response.auth.*;
+import com.codeit.todo.web.dto.response.complete.ReadTargetUserCompleteResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -29,12 +32,15 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.security.SignatureException;
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Objects;
 
 @Service
 @RequiredArgsConstructor
 public class UserServiceImpl implements UserService {
     private final UserRepository userRepository;
+    private final GoalRepository goalRepository;
+    private final FollowRepository followRepository;
     private final AuthenticationManager authenticationManager;
     private final JwtTokenProvider jwtTokenProvider;
     private final PasswordEncoder passwordEncoder;
@@ -133,6 +139,23 @@ public class UserServiceImpl implements UserService {
         user.updatePassword(encodedPassword);
 
         return new UpdatePasswordResponse(userId);
+    }
+
+    @Transactional(readOnly = true)
+    @Override
+    public ReadTargetUserResponse findTargetUserProfile(int userId, int targetUserId) {
+        User targetUser = getUser(targetUserId);
+
+        boolean isFollow = followRepository.existsByFollower_FollowerIdAndFollowee_FolloweeId(userId, targetUserId);
+
+        List<ReadTargetUserCompleteResponse> responses = goalRepository.findByUser_UserId(targetUserId).stream()
+                .flatMap(goal -> goal.getTodos().stream())
+                .flatMap(todo -> todo.getCompletes().stream())
+                .map(ReadTargetUserCompleteResponse::from)
+                .toList();
+
+        return ReadTargetUserResponse.from(targetUser, isFollow, responses);
+
     }
 
     private User getUser(int userId){

--- a/src/main/java/com/codeit/todo/web/controller/AuthController.java
+++ b/src/main/java/com/codeit/todo/web/controller/AuthController.java
@@ -1,6 +1,5 @@
 package com.codeit.todo.web.controller;
 
-import com.codeit.todo.common.config.JwtTokenProvider;
 import com.codeit.todo.repository.CustomUserDetails;
 import com.codeit.todo.service.user.UserService;
 import com.codeit.todo.web.dto.request.auth.LoginRequest;
@@ -8,6 +7,7 @@ import com.codeit.todo.web.dto.request.auth.SignUpRequest;
 import com.codeit.todo.web.dto.request.auth.UpdatePasswordRequest;
 import com.codeit.todo.web.dto.request.auth.UpdatePictureRequest;
 import com.codeit.todo.web.dto.response.Response;
+import com.codeit.todo.web.dto.response.auth.ReadTargetUserResponse;
 import com.codeit.todo.web.dto.response.auth.UpdatePasswordResponse;
 import com.codeit.todo.web.dto.response.auth.UpdatePictureResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -89,5 +89,18 @@ public class AuthController {
             ) {
         int userId = userDetails.getUserId();
         return Response.ok(userService.updatePassword(userId, passwordRequest));
+    }
+
+    @Operation(summary = "다른 유저의 프로필 가져오기", description = "다른 유저의 이름, 이메일, 팔로우 여부,  인증 사진 가져오기")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "조회 성공")
+    })
+    @GetMapping(value = "/profile/{targetUserId}")
+    public Response<ReadTargetUserResponse> getTargetUserProfile(
+            @AuthenticationPrincipal CustomUserDetails customUserDetails,
+            @PathVariable int targetUserId
+            ){
+        int userId = customUserDetails.getUserId();
+        return Response.ok( userService.findTargetUserProfile(userId, targetUserId) );
     }
 }

--- a/src/main/java/com/codeit/todo/web/dto/response/auth/ReadTargetUserResponse.java
+++ b/src/main/java/com/codeit/todo/web/dto/response/auth/ReadTargetUserResponse.java
@@ -1,0 +1,24 @@
+package com.codeit.todo.web.dto.response.auth;
+
+import com.codeit.todo.domain.User;
+import com.codeit.todo.web.dto.response.complete.ReadTargetUserCompleteResponse;
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+public record ReadTargetUserResponse(
+        String name,
+        String profilePic,
+        boolean isFollow,
+        List<ReadTargetUserCompleteResponse> completeResponses
+) {
+    public static ReadTargetUserResponse from(User user, boolean isFollow, List<ReadTargetUserCompleteResponse> completeResponses){
+        return ReadTargetUserResponse.builder()
+                .name(user.getName())
+                .profilePic(user.getProfilePic())
+                .isFollow(isFollow)
+                .completeResponses(completeResponses)
+                .build();
+    }
+}

--- a/src/main/java/com/codeit/todo/web/dto/response/complete/ReadTargetUserCompleteResponse.java
+++ b/src/main/java/com/codeit/todo/web/dto/response/complete/ReadTargetUserCompleteResponse.java
@@ -1,0 +1,20 @@
+package com.codeit.todo.web.dto.response.complete;
+
+import com.codeit.todo.domain.Complete;
+import lombok.Builder;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Builder
+public record ReadTargetUserCompleteResponse(
+        int completeId,
+        String completePic
+) {
+    public static ReadTargetUserCompleteResponse from(Complete complete) {
+        return ReadTargetUserCompleteResponse.builder()
+                .completeId(complete.getCompleteId())
+                .completePic(complete.getCompletePic())
+                .build();
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

- close #133 

## 📝작업 내용
- 로그인해야만 다른 유저의 프로필을 확인할 수 있습니다. 
- 다른 유저의 정보(이름, 사진), 팔로잉 여부, 인증 사진들을 가져옵니다. 
- 타인 아이디로 타인의 목표 -> 할 일 -> 인증 사진까지 조회하기 위해 `flatMap`을 사용하였습니다. 

### 스크린샷 (선택)
<img width="786" alt="Screenshot 2024-12-27 at 01 08 49" src="https://github.com/user-attachments/assets/fcf9bab7-091f-40e0-83fe-08538ddfae46" />

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메소드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?