### PR TITLE
feat: 회원 탈퇴

### DIFF
--- a/src/main/java/com/codeit/todo/common/config/JwtTokenProvider.java
+++ b/src/main/java/com/codeit/todo/common/config/JwtTokenProvider.java
@@ -4,20 +4,19 @@ import com.codeit.todo.common.exception.jwt.JwtException;
 import com.codeit.todo.common.exception.payload.ErrorStatus;
 import io.jsonwebtoken.*;
 import jakarta.annotation.PostConstruct;
-import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.http.ResponseCookie;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
-import org.springframework.security.core.parameters.P;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.stereotype.Component;
 
 import java.util.Base64;
 import java.util.Date;
+import java.util.HashSet;
+import java.util.Set;
 
 @Component
 @RequiredArgsConstructor
@@ -91,4 +90,12 @@ public class JwtTokenProvider {
     }
 
 
+    private final Set<String> tokenBlackList = new HashSet<>();
+    public void addToBlackList(String currentToken) {
+        tokenBlackList.add(currentToken);
+    }
+
+    public boolean isTokenBlackListed(String jwtToken){
+        return tokenBlackList.contains(jwtToken);
+    }
 }

--- a/src/main/java/com/codeit/todo/domain/User.java
+++ b/src/main/java/com/codeit/todo/domain/User.java
@@ -63,4 +63,6 @@ public class User {
     public void updatePassword(String password){
         this.password = password;
     }
+
+    public void updateStatus(){this.userStatus = "탈퇴";}
 }

--- a/src/main/java/com/codeit/todo/domain/User.java
+++ b/src/main/java/com/codeit/todo/domain/User.java
@@ -31,6 +31,10 @@ public class User {
     @Column(name = "profile_pic", nullable = false)
     private String profilePic;
 
+    @Column(name = "user_status", nullable = false)
+    private String userStatus;
+
+
     @OneToMany(mappedBy= "user", cascade = CascadeType.REMOVE, orphanRemoval = true)
     private List<Goal> goals = new ArrayList<>();
 
@@ -43,12 +47,13 @@ public class User {
     private List<Follow> followees = new ArrayList<>();
 
     @Builder
-    public User(int userId, String name, String email, String password, String profilePic) {
+    public User(int userId, String name, String email, String password, String profilePic, String userStatus) {
         this.userId = userId;
         this.name = name;
         this.email = email;
         this.password = password;
         this.profilePic = profilePic;
+        this.userStatus = userStatus;
     }
 
     public void updateProfilePic(String completePicUrl){

--- a/src/main/java/com/codeit/todo/repository/CommentRepository.java
+++ b/src/main/java/com/codeit/todo/repository/CommentRepository.java
@@ -3,7 +3,11 @@ package com.codeit.todo.repository;
 
 import com.codeit.todo.domain.Comment;
 import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
 public interface CommentRepository extends JpaRepository<Comment, Integer> {
 
+    List<Comment> findByUser_UserId(int userId);
 }
 

--- a/src/main/java/com/codeit/todo/repository/FollowRepository.java
+++ b/src/main/java/com/codeit/todo/repository/FollowRepository.java
@@ -3,6 +3,7 @@ package com.codeit.todo.repository;
 
 import com.codeit.todo.domain.Follow;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -28,5 +29,17 @@ public interface FollowRepository extends JpaRepository<Follow, Integer> {
 
     @Query("select f.followee.userId from Follow f where f.follower.userId = :userId")
     List<Integer> findFolloweeIdsByFollowerId(@Param("userId") int userId);
+
+    @Modifying
+    @Query
+            ("DELETE FROM Follow  f " +
+                    "WHERE f.followee.userId = :userId ")
+    void deleteByFolloweeUserId(@Param("userId") int userId);
+
+    @Modifying
+    @Query(
+            "DELETE FROM Follow f " +
+                    "WHERE f.follower.userId = :userId ")
+    void deleteByFollowerUserId(@Param("userId") int userId);
 }
 

--- a/src/main/java/com/codeit/todo/repository/GoalRepository.java
+++ b/src/main/java/com/codeit/todo/repository/GoalRepository.java
@@ -4,6 +4,7 @@ import com.codeit.todo.domain.Goal;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -40,4 +41,9 @@ and :today between t.startDate and t.endDate
     Slice<Goal> findByUserAndHasTodosAfterLastGoalId(@Param("lastGoalId") Integer lastGoalId, @Param("userId") int userId, Pageable pageable,  @Param("today") LocalDate today);
 
     List<Goal> findByGoalTitleContains(@Param("keyword") String keyword);
+
+    @Modifying
+    @Query("DELETE FROM Goal g " +
+            "WHERE g.user.userId = :userId")
+    void deleteByUserId(@Param("userId") int userId);
 }

--- a/src/main/java/com/codeit/todo/repository/GoalRepository.java
+++ b/src/main/java/com/codeit/todo/repository/GoalRepository.java
@@ -42,8 +42,8 @@ and :today between t.startDate and t.endDate
 
     List<Goal> findByGoalTitleContains(@Param("keyword") String keyword);
 
-    @Modifying
-    @Query("DELETE FROM Goal g " +
-            "WHERE g.user.userId = :userId")
-    void deleteByUserId(@Param("userId") int userId);
+//    @Modifying
+//    @Query("DELETE FROM Goal g " +
+//            "WHERE g.user.userId = :userId")
+//    void deleteByUserId(@Param("userId") int userId);
 }

--- a/src/main/java/com/codeit/todo/repository/GoalRepository.java
+++ b/src/main/java/com/codeit/todo/repository/GoalRepository.java
@@ -42,8 +42,4 @@ and :today between t.startDate and t.endDate
 
     List<Goal> findByGoalTitleContains(@Param("keyword") String keyword);
 
-//    @Modifying
-//    @Query("DELETE FROM Goal g " +
-//            "WHERE g.user.userId = :userId")
-//    void deleteByUserId(@Param("userId") int userId);
 }

--- a/src/main/java/com/codeit/todo/repository/LikesRepository.java
+++ b/src/main/java/com/codeit/todo/repository/LikesRepository.java
@@ -3,10 +3,13 @@ package com.codeit.todo.repository;
 import com.codeit.todo.domain.Likes;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface LikesRepository extends JpaRepository<Likes, Integer> {
     Boolean existsByUser_UserIdAndComplete_CompleteId(int userId, int completeId);
 
     Optional<Likes> findByComplete_CompleteIdAndUser_UserId(int completeId, int userId);
+
+    List<Likes> findByUser_UserId(int userId);
 }

--- a/src/main/java/com/codeit/todo/service/user/UserService.java
+++ b/src/main/java/com/codeit/todo/service/user/UserService.java
@@ -21,4 +21,6 @@ public interface UserService {
     ReadTargetUserResponse findTargetUserProfile(int userId, int targetUserId);
 
     ReadMyPageResponse findUserInfoAndFollows(int userId);
+
+    UpdateUserStatusResponse updateUserStatus(int userId);
 }

--- a/src/main/java/com/codeit/todo/service/user/impl/UserServiceImpl.java
+++ b/src/main/java/com/codeit/todo/service/user/impl/UserServiceImpl.java
@@ -2,6 +2,7 @@ package com.codeit.todo.service.user.impl;
 
 import com.codeit.todo.common.config.JwtTokenProvider;
 import com.codeit.todo.common.exception.ApplicationException;
+import com.codeit.todo.common.exception.auth.AuthorizationDeniedException;
 import com.codeit.todo.common.exception.payload.ErrorStatus;
 import com.codeit.todo.common.exception.user.SignUpException;
 import com.codeit.todo.common.exception.user.UpdatePasswordException;
@@ -78,6 +79,7 @@ public class UserServiceImpl implements UserService {
         try{
             User user = userRepository.findByEmail(email)
                     .orElseThrow(()-> new UserNotFoundException(email, "User"));
+            if(user.getUserStatus().equals("탈퇴")) throw new AuthorizationDeniedException("탈퇴한 회원입니다. 로그인 권한이 없습니다. ");
 
             Authentication authentication = authenticationManager.authenticate(new UsernamePasswordAuthenticationToken(email, password));
             SecurityContextHolder.getContext().setAuthentication(authentication);

--- a/src/main/java/com/codeit/todo/service/user/impl/UserServiceImpl.java
+++ b/src/main/java/com/codeit/todo/service/user/impl/UserServiceImpl.java
@@ -175,13 +175,10 @@ public class UserServiceImpl implements UserService {
 
         followRepository.deleteByFolloweeUserId(userId);
         followRepository.deleteByFollowerUserId(userId);
-//        goalRepository.deleteByUserId(userId);
 
         goalRepository.findByUser_UserId(userId).forEach(goalRepository::delete);
         likesRepository.findByUser_UserId(userId).forEach(likesRepository::delete);
         commentRepository.findByUser_UserId(userId).forEach(commentRepository::delete);
-
-
 
         return UpdateUserStatusResponse.from(userId);
     }

--- a/src/main/java/com/codeit/todo/service/user/impl/UserServiceImpl.java
+++ b/src/main/java/com/codeit/todo/service/user/impl/UserServiceImpl.java
@@ -162,6 +162,19 @@ public class UserServiceImpl implements UserService {
         return ReadMyPageResponse.from(followerCount, followeeCount);
     }
 
+    @Transactional
+    @Override
+    public UpdateUserStatusResponse updateUserStatus(int userId) {
+        User user = getUser(userId);
+        user.updateStatus();
+
+        followRepository.deleteByFolloweeUserId(userId);
+        followRepository.deleteByFollowerUserId(userId);
+        goalRepository.deleteByUserId(userId);
+
+        return UpdateUserStatusResponse.from(userId);
+    }
+
     public User getUser(int userId){
         User user = userRepository.findById(userId)
                 .orElseThrow(()-> new UserNotFoundException(String.valueOf(userId), "User"));

--- a/src/main/java/com/codeit/todo/web/controller/AuthController.java
+++ b/src/main/java/com/codeit/todo/web/controller/AuthController.java
@@ -123,7 +123,7 @@ public class AuthController {
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "탈퇴 성공")
     })
-    @PutMapping("/withdrawl")
+    @DeleteMapping("/withdrawl")
     public Response<UpdateUserStatusResponse> userWithdraw(
             HttpServletRequest request,
             @AuthenticationPrincipal CustomUserDetails userDetails

--- a/src/main/java/com/codeit/todo/web/controller/AuthController.java
+++ b/src/main/java/com/codeit/todo/web/controller/AuthController.java
@@ -7,10 +7,7 @@ import com.codeit.todo.web.dto.request.auth.SignUpRequest;
 import com.codeit.todo.web.dto.request.auth.UpdatePasswordRequest;
 import com.codeit.todo.web.dto.request.auth.UpdatePictureRequest;
 import com.codeit.todo.web.dto.response.Response;
-import com.codeit.todo.web.dto.response.auth.ReadMyPageResponse;
-import com.codeit.todo.web.dto.response.auth.ReadTargetUserResponse;
-import com.codeit.todo.web.dto.response.auth.UpdatePasswordResponse;
-import com.codeit.todo.web.dto.response.auth.UpdatePictureResponse;
+import com.codeit.todo.web.dto.response.auth.*;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
@@ -114,6 +111,21 @@ public class AuthController {
     public Response<ReadMyPageResponse> getMyPage(@AuthenticationPrincipal CustomUserDetails customUserDetails){
         int userId = customUserDetails.getUserId();
         return Response.ok( userService.findUserInfoAndFollows(userId));
+    }
+
+    @Operation(
+            summary = "회원 탈퇴",
+            description = "user_status를 '탈퇴'로 변경하고 목표, 할일, 인증, 좋아요, 댓글, 팔로워, 팔로이를 모두 삭제"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "탈퇴 성공")
+    })
+    @PutMapping("/withdrawl")
+    public Response<UpdateUserStatusResponse> userWithdraw(
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        int userId = userDetails.getUserId();
+        return Response.ok(userService.updateUserStatus(userId));
     }
 
 }

--- a/src/main/java/com/codeit/todo/web/dto/request/auth/SignUpRequest.java
+++ b/src/main/java/com/codeit/todo/web/dto/request/auth/SignUpRequest.java
@@ -23,6 +23,7 @@ public record SignUpRequest(
                 .email(this.email)
                 .password(encodedPassword)
                 .profilePic(profilePic)
+                .userStatus("가입")
                 .build();
     }
 

--- a/src/main/java/com/codeit/todo/web/dto/response/auth/UpdateUserStatusResponse.java
+++ b/src/main/java/com/codeit/todo/web/dto/response/auth/UpdateUserStatusResponse.java
@@ -1,0 +1,14 @@
+package com.codeit.todo.web.dto.response.auth;
+
+import lombok.Builder;
+
+@Builder
+public record UpdateUserStatusResponse(int userId) {
+
+    public static UpdateUserStatusResponse from(int userId) {
+        return UpdateUserStatusResponse.builder()
+                .userId(userId)
+                .build();
+    }
+
+}

--- a/src/main/java/com/codeit/todo/web/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/codeit/todo/web/filter/JwtAuthenticationFilter.java
@@ -37,6 +37,14 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                 ));
             }
 
+            if(jwtTokenProvider.isTokenBlackListed(jwtToken)){
+                log.info("블랙리스트에 추가된 토큰 : {}", jwtToken);
+                throw new JwtException(ErrorStatus.toErrorStatus(
+                        "블랙리스트에 추가되어 있는 토큰입니다.", 401
+
+                ));
+            }
+
             log.info("토큰이 인식되었습니다. : {}", jwtToken);
             if (jwtTokenProvider.validToken(jwtToken)) {
                 log.info("토큰이 유효합니다. : {}", jwtToken);


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

- close #148 

## 📝작업 내용

- 유저에 user_status를 추가하였습니다. 회원가입을 하면  `가입`으로 설정하고, 탈퇴하면 `탈퇴`로 변경됩니다. 
- user_status가 `탈퇴`인 유저는 로그인 할 수 없습니다. 
- 회원 탈퇴시 유저의 모든 모든 목표, 할 일, 인증, 좋아요, 댓글, 팔로워, 팔로이는 삭제됩니다. 
- 탈퇴하는 즉시 토큰은 블랙리스트에 추가되며, 로그인이 필요한 API들은 사용할 수 없습니다. 

### 스크린샷 (선택)
#### 탈퇴 후 응답
<img width="684" alt="Screenshot 2024-12-28 at 23 23 23" src="https://github.com/user-attachments/assets/9417fc55-e8b6-424d-ba22-a266c76b815c" />

#### 탈퇴 후 로그인을 시도했을 때 예외처리
<img width="679" alt="Screenshot 2024-12-28 at 23 23 50" src="https://github.com/user-attachments/assets/750ab4aa-bb14-42d8-9509-6cb90544f0ad" />

#### 탈퇴 후 토큰이 필요한 API를 시도했을 때 예외처리
<img width="678" alt="Screenshot 2024-12-28 at 23 24 19" src="https://github.com/user-attachments/assets/2d9ee5db-f5d2-4b9c-94e2-2a36e373b7b9" />


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
회원탈퇴의 경우 유저는 변경이고, 유저에 딸린 목표/할일/인증 등등은 삭제입니다. 
`Mappping`을 `PUT`으로 할지 `DELETE`로 할지 고민하다가 유저에 대한 API이고 유저는 status변경이니 `PUT`으로 구현했습니다. 
어떻게 생각하시는지 궁금합니다. 