### PR TITLE
fix: 팔로우 여부 찾아오는 쿼리 수정

### DIFF
--- a/src/main/java/com/codeit/todo/repository/FollowRepository.java
+++ b/src/main/java/com/codeit/todo/repository/FollowRepository.java
@@ -12,9 +12,9 @@ import java.util.Optional;
 public interface FollowRepository extends JpaRepository<Follow, Integer> {
     @Query(
             "SELECT COUNT(f) > 0 " +
-                    "from Follow f " +
-                    "WHERE f.followee.userId = :userId " +
-                    "AND f.follower.userId = :targetUserId "
+                    "FROM Follow f " +
+                    "WHERE f.follower.userId = :userId " +
+                    "AND f.followee.userId = :targetUserId "
     )
     boolean existsByFollower_FollowerIdAndFollowee_FolloweeId(@Param("userId")int userId, @Param("targetUserId")int targetUserId);
 

--- a/src/main/java/com/codeit/todo/service/follow/impl/FollowServiceImpl.java
+++ b/src/main/java/com/codeit/todo/service/follow/impl/FollowServiceImpl.java
@@ -67,7 +67,7 @@ public class FollowServiceImpl implements FollowService {
 
     @Override
     public CreateFollowResponse registerFollow(int followerId, int followeeId) {
-        if (followRepository.existsByFollower_FollowerIdAndFollowee_FolloweeId(followeeId, followerId)) {
+        if (followRepository.existsByFollower_FollowerIdAndFollowee_FolloweeId(followerId, followeeId)) {
             throw new AuthorizationDeniedException("이미 팔로우로 등록한 회원입니다.");
         }
 
@@ -82,7 +82,7 @@ public class FollowServiceImpl implements FollowService {
 
     @Override
     public DeleteFollowResponse cancelFollow(int followerId, int followeeId) {
-        if (!followRepository.existsByFollower_FollowerIdAndFollowee_FolloweeId(followeeId, followerId)) {
+        if (!followRepository.existsByFollower_FollowerIdAndFollowee_FolloweeId(followerId, followeeId)) {
             throw new AuthorizationDeniedException("팔로우 내역이 존재하지 않습니다.");
         }
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

- close #153 
- 
## 📝작업 내용

> 팔로우를 찾아오는 쿼리의 파라미터를 수정했습니다. 
> 현석님이 예외처리 할 때 사용하신 부분도 파라미터 순서를 바꿔 두었습니다. 

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

- 현석님이 만드신 `createFollow`는 내가 타인을 팔로우 등록하는 쿼리가 맞지요?
그러면 예를 들어 제가 1번이고 팔로우하고 싶은 사람이 10번이면, 
DB에 팔로이에 10번이 들어가고, 팔로우에 1번이 들어가야 하는게 아닐까요? 현재는 반대로 작동합니다. 