### PR TITLE
fix: 무한스크롤 할 때 lastGoalId부터 불러오기로 수정

### DIFF
--- a/src/main/java/com/codeit/todo/repository/GoalRepository.java
+++ b/src/main/java/com/codeit/todo/repository/GoalRepository.java
@@ -18,7 +18,12 @@ public interface GoalRepository extends JpaRepository<Goal, Integer> {
 
     Slice<Goal> findByUser_UserId(@Param("userId") int userId, Pageable pageable);
 
-    Slice<Goal> findByGoalIdAndUser_UserId(@Param("lastGoalId") Integer lastGoalId, @Param("userId") int userId, Pageable pageable);
+    @Query(
+            "SELECT g FROM Goal g " +
+                    "WHERE g.user.userId = :userId " +
+                    "AND g.goalId > :lastGoalId "
+    )
+    Slice<Goal> findByGoalIdAndUser_UserIdAndGoalIdGreaterThan(@Param("userId") int userId, @Param("lastGoalId")int lastGoalId, Pageable pageable);
 
     @Query("""
 select g
@@ -40,4 +45,5 @@ and :today between t.startDate and t.endDate
     Slice<Goal> findByUserAndHasTodosAfterLastGoalId(@Param("lastGoalId") Integer lastGoalId, @Param("userId") int userId, Pageable pageable,  @Param("today") LocalDate today);
 
     List<Goal> findByGoalTitleContains(@Param("keyword") String keyword);
+
 }

--- a/src/main/java/com/codeit/todo/service/goal/impl/GoalServiceImpl.java
+++ b/src/main/java/com/codeit/todo/service/goal/impl/GoalServiceImpl.java
@@ -137,7 +137,8 @@ public class GoalServiceImpl implements GoalService {
         if (Objects.isNull(request.lastGoalId()) || request.lastGoalId() <= 0) {
             goals = goalRepository.findByUser_UserId(userId, pageable);
         } else {
-            goals = goalRepository.findByGoalIdAndUser_UserId(request.lastGoalId(), userId, pageable);
+            int lastGoalId = request.lastGoalId();
+            goals = goalRepository.findByGoalIdAndUser_UserIdAndGoalIdGreaterThan(userId, lastGoalId, pageable);
         }
         return goals;
     }


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

- close #155 

## 📝작업 내용

> lastGoalId 이후로 목표를 size수만큼 불러오도록 수정합니다. 

### 스크린샷 (선택)
<img width="820" alt="Screenshot 2024-12-29 at 11 48 28" src="https://github.com/user-attachments/assets/ff565e2c-6088-41a5-955c-96a8af2a56c2" />



## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메소드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?