### PR TITLE
fix: 목표가 없을 때 빈 배열을 보내기

### DIFF
--- a/src/main/java/com/codeit/todo/service/goal/impl/GoalServiceImpl.java
+++ b/src/main/java/com/codeit/todo/service/goal/impl/GoalServiceImpl.java
@@ -6,7 +6,6 @@ import com.codeit.todo.common.exception.user.UserNotFoundException;
 import com.codeit.todo.domain.Goal;
 import com.codeit.todo.domain.Todo;
 import com.codeit.todo.domain.User;
-import com.codeit.todo.repository.CompleteRepository;
 import com.codeit.todo.repository.GoalRepository;
 import com.codeit.todo.repository.TodoRepository;
 import com.codeit.todo.repository.UserRepository;
@@ -49,10 +48,6 @@ public class GoalServiceImpl implements GoalService {
     @Override
     public List<ReadGoalsResponse> findGoalList(int userId) {
         List<Goal> goals= goalRepository.findByUser_UserId(userId);
-
-        if (goals.isEmpty()) {
-            throw new GoalNotFoundException("0");
-        }
 
         return goals.stream()
                 .map(goal-> {


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

- close #163

## 📝작업 내용

> 목표 제목만 조회하는 api에서 등록된 목표가 없을 때 예외처리를 하는게 아니라, 빈 배열을 보냅니다. 
- 대시보드에서 사용되는 api입니다. 
- 프론트와 상의 이후, 404로 예외처리를 하는 것보다 빈 배열이라도 받아오는게 낫다고 판단하였습니다. 

### 스크린샷 (선택)
<img width="680" alt="Screenshot 2024-12-30 at 13 34 44" src="https://github.com/user-attachments/assets/2fc34627-cb14-4029-a3c7-e876f111bc41" />


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메소드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?