### PR TITLE
fix: 팔로워, 팔로이 수 세는 쿼리 수정

### DIFF
--- a/src/main/java/com/codeit/todo/repository/FollowRepository.java
+++ b/src/main/java/com/codeit/todo/repository/FollowRepository.java
@@ -20,11 +20,11 @@ public interface FollowRepository extends JpaRepository<Follow, Integer> {
     boolean existsByFollower_FollowerIdAndFollowee_FolloweeId(@Param("userId")int userId, @Param("targetUserId")int targetUserId);
 
     @Query("SELECT COUNT(*) FROM Follow f " +
-            "WHERE f.followee.userId = :userId ")
+            "WHERE f.follower.userId = :userId ")
     int countByFollower(@Param("userId") int userId);
 
     @Query("SELECT COUNT(*) FROM Follow f " +
-            "WHERE f.follower.userId = :userId ")
+            "WHERE f.followee.userId = :userId ")
     int countByFollowee(@Param("userId") int userId);
 
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

- close #160 

## 📝작업 내용

> 팔로워, 팔로이 쿼리가 수를 반대로 세어 와서 수정하였습니다. 

### 스크린샷 (선택)
<img width="233" alt="Screenshot 2024-12-30 at 13 45 32" src="https://github.com/user-attachments/assets/64040e21-74c2-454b-9443-f71798ccecd2" />

<img width="407" alt="Screenshot 2024-12-30 at 13 45 43" src="https://github.com/user-attachments/assets/264fe186-8a51-4d44-8f4a-30f11e980d04" />


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메소드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?