### PR TITLE
fix: 팔로우 여부 찾아오는 쿼리 수정

### DIFF
--- a/src/main/java/com/codeit/todo/repository/FollowRepository.java
+++ b/src/main/java/com/codeit/todo/repository/FollowRepository.java
@@ -14,8 +14,8 @@ public interface FollowRepository extends JpaRepository<Follow, Integer> {
     @Query(
             "SELECT COUNT(f) > 0 " +
                     "FROM Follow f " +
-                    "WHERE f.follower.userId = :userId " +
-                    "AND f.followee.userId = :targetUserId "
+                    "WHERE f.follower.userId = :targetUserId " +
+                    "AND f.followee.userId = :userId "
     )
     boolean existsByFollower_FollowerIdAndFollowee_FolloweeId(@Param("userId")int userId, @Param("targetUserId")int targetUserId);
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

- close #172 

## 📝작업 내용

> 타인 프로필 페이지에서 팔로우 여부(isFollow)를 찾아오는 쿼리를 수정합니다. 

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메소드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?