### PR TITLE
fix : 팔로우 쿼리문에 전달할 파라미터 순서 변경

### DIFF
--- a/src/main/java/com/codeit/todo/service/follow/impl/FollowServiceImpl.java
+++ b/src/main/java/com/codeit/todo/service/follow/impl/FollowServiceImpl.java
@@ -67,7 +67,7 @@ public class FollowServiceImpl implements FollowService {
 
     @Override
     public CreateFollowResponse registerFollow(int followerId, int followeeId) {
-        if (followRepository.existsByFollower_FollowerIdAndFollowee_FolloweeId(followerId, followeeId)) {
+        if (followRepository.existsByFollower_FollowerIdAndFollowee_FolloweeId(followeeId, followerId)) {
             throw new AuthorizationDeniedException("이미 팔로우로 등록한 회원입니다.");
         }
 
@@ -82,7 +82,7 @@ public class FollowServiceImpl implements FollowService {
 
     @Override
     public DeleteFollowResponse cancelFollow(int followerId, int followeeId) {
-        if (!followRepository.existsByFollower_FollowerIdAndFollowee_FolloweeId(followerId, followeeId)) {
+        if (!followRepository.existsByFollower_FollowerIdAndFollowee_FolloweeId(followeeId, followerId)) {
             throw new AuthorizationDeniedException("팔로우 내역이 존재하지 않습니다.");
         }
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

- close #이슈번호

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- 팔로우 존재 확인하는 쿼리문에 전달할 파라미터 순서 변경했습니다.
- 쿼리문 순서를 변경하는게 맞겠지만 소희님 코드와도 연관돼있어서 우선 제가 전달하는 파라미터 순서를 변경했습니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메소드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

그 쿼리문쪽 수정사항을 제가 잘 못 전달한거 같습니다.

```java
    @Query(
            "SELECT COUNT(f) > 0 " +
                    "FROM Follow f " +
                    "WHERE f.follower.userId = :targetUserId " +
                    "AND f.followee.userId = :userId "
    )
    boolean existsByFollower_FollowerIdAndFollowee_FolloweeId(@Param("userId")int userId, @Param("targetUserId")int targetUserId);
```

이 부분 메소드명에 의하면 followerId, followeeId 순으로 찾게끔 되어있으나 실제로는 followeeId 파라미터를 씁니다. 그래서 변경이 된다면 


```java
    @Query(
            "SELECT COUNT(f) > 0 " +
                    "FROM Follow f " +
                    "WHERE f.follower.userId = :userId" +
                    "AND f.followee.userId = :targetUserId"
    )
    boolean existsByFollower_FollowerIdAndFollowee_FolloweeId(@Param("userId")int userId, @Param("targetUserId")int targetUserId);
```

이렇게 쓰는게 메소드 의도와 실제 쿼리가 일치해요. 혹은


```java
    @Query(
            "SELECT COUNT(f) > 0 " +
                    "FROM Follow f " +
                    "WHERE f.follower.userId = :follwerId" +
                    "AND f.followee.userId = :follweeId"
    )
    boolean existsByFollower_FollowerIdAndFollowee_FolloweeId(@Param("follwerId")int follwerId, @Param("follweeId")int follweeId);
```

이런식으로 헷갈리지 않게 필드명을 일치시키는 것도 방법인 것 같습니다.